### PR TITLE
shape-path-query: fix for when resultBindings is an array

### DIFF
--- a/packages/shex-shape-path-query/package.json
+++ b/packages/shex-shape-path-query/package.json
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "main": "./shape-path-query.js",
-  "type": "package",
+  "type": "commonjs",
   "engines": {
     "node": ">=0.10.0"
   },

--- a/packages/shex-shape-path-query/shape-path-query.js
+++ b/packages/shex-shape-path-query/shape-path-query.js
@@ -3,7 +3,6 @@ const ShExUtil = require('@shexjs/util')
 const ShExTerm = require('@shexjs/term')
 const ShExMap = require('@shexjs/extension-map')
 const MapModule = ShExMap(ShExTerm)
-const RdfStore = require('n3').Store
 
 function shapePathQuery (schema, nodeSet, db, smap) {
   // Add ShExMap annotations to each element of the nodeSet.
@@ -22,7 +21,7 @@ function shapePathQuery (schema, nodeSet, db, smap) {
 
   // Construct validator with ShapeMap semantic action handler.
   const validator = ShExValidator.construct(schema, db, {})
-  const mapper = MapModule.register(validator, { ShExTerm })
+  MapModule.register(validator, { ShExTerm })
 
   // Validate data against schema.
   const valRes = validator.validate(smap)
@@ -30,9 +29,9 @@ function shapePathQuery (schema, nodeSet, db, smap) {
     throw Error(JSON.stringify(valRes, undefined, 2));
   } else {
     // Return values extracted from data.
-    const resultBindings = ShExUtil.valToExtension(valRes, MapModule.url)
-    const values = vars.map(v => resultBindings[v])
-    return values
+    let resultBindings = ShExUtil.valToExtension(valRes, MapModule.url)
+    if (!Array.isArray(resultBindings)) resultBindings = [ resultBindings ]
+    return vars.flatMap(v => resultBindings.map(b => b[v]))
   }
 }
 


### PR DESCRIPTION
Original code was working only when `resultBindings` was an object, for example:

```js
{
  'http://a.example/binding-0': 'https://pro.alice.example/106a82aa-6911-4a7e-a49b-383cbaa9da66#task'
}
```

it was failing and returning `[ undefined ]` when `resultBindings` was an array

```js
[
  {
    'http://a.example/binding-0': 'https://pro.alice.example/106a82aa-6911-4a7e-a49b-383cbaa9da66#task'
  },
  {
    'http://a.example/binding-0': 'https://pro.alice.example/576520a6-af5a-4cf9-8b40-8b1512b59c73#task'
  }
]
```

My solution works in my use case since `vars` has only one element
```js
[ 'http://a.example/binding-0' ]
```

I don't know how result supposed to be formatted if `vars` has more elements, currently it just creates a flat array.

It can be tested with https://github.com/elf-pavlik/shapepath-node-for-pavlik I just `npm link` this module to use local version.