### PR TITLE
fix: Only manually capture stack trace in needed environments

### DIFF
--- a/packages/shex-validator/src/shex-validator.ts
+++ b/packages/shex-validator/src/shex-validator.ts
@@ -1405,6 +1405,8 @@ function _seq<T> (n: number): (T | undefined)[] {
 function runtimeError (... args: string[]): never {
   const errorStr = args.join("");
   const e = new Error(errorStr);
-  Error.captureStackTrace(e, runtimeError);
+  if ("captureStackTrace" in Error) {
+    Error.captureStackTrace(e, runtimeError);
+  }
   throw e;
 }


### PR DESCRIPTION
In firefox I get an Error when validation fails, it says "Error.captureStackTrace" is not a function, this is not the best fix as it's only fixing it for the validator instead of everywhere where it appears. I couldn't find much info online about this, it just seems like captureStackTrace is not needed in every js env as the stack is automatically captured in firefox at least. See this issue https://github.com/ProtoDef-io/node-protodef/issues/100