### PR TITLE
Fixes #365 fix blinking cursor not shown enough in Query Map

### DIFF
--- a/packages/shex-webapp/doc/shex-simple.html
+++ b/packages/shex-webapp/doc/shex-simple.html
@@ -39,6 +39,8 @@
         border-width: 2px;
         padding: 1px 0px;
       }
+      /* adds a bit of left padding to textMap to fix issue with blinking cursor on left edge not shown enough when element gets bordered and is focused */      
+      #textMap { padding-left: .4em }
       ul[data-navColumn] button:focus::before { content: "> "; color: #730; margin-left: -1em; }
       ul[data-navColumn] button:focus::after  { content: " <"; color: #730; margin-right: -1em; }
       .schema.textarea, .schema, .schema.ui-dialog-content { background-color: #f4f4ff; color: #000000; border-color: #fc561c }


### PR DESCRIPTION
Fix #365
- to be minimally impactful for downstream apps like Wikidata shex-simple.toolforge.org , I think this is best done in only the `#textMap` rather than all `#inputarea` 's ?  dunno.