### PR TITLE
deps: drop node-fetch and chalk for built-ins (both ESM-only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "jsdom": "^30.0.1",
         "mocha": "^11.7.6",
         "nock": "^14.0.16",
-        "node-fetch": "^2.7.0",
         "nyc": "^18.0.0",
         "pre-commit": "^1.2.2",
         "shex-test": "github:shexSpec/shexTest#main",
@@ -12360,6 +12359,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -12378,17 +12378,20 @@
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -16673,7 +16676,6 @@
         "@shexjs/util": "^1.0.0-alpha.30",
         "@shexjs/visitor": "^1.0.0-alpha.30",
         "@shexjs/webapp": "^1.0.0-alpha.30",
-        "chalk": "^4.1.2",
         "command-line-args": "^6.0.2",
         "command-line-usage": "^7.0.3",
         "n3": "^2.7.4",
@@ -17520,7 +17522,6 @@
         "@shexjs/validator": "^1.0.0-alpha.30",
         "@shexjs/visitor": "^1.0.0-alpha.30",
         "@shexjs/writer": "^1.0.0-alpha.30",
-        "chalk": "^4.1.2",
         "command-line-args": "^6.0.2",
         "command-line-usage": "^7.0.3",
         "js-yaml": "^5.4.1",
@@ -17529,7 +17530,6 @@
         "koa-body": "^6.0.1",
         "lezer-turtle": "^0.1.0",
         "n3": "^2.7.4",
-        "node-fetch": "^2.7.0",
         "shape-map": "^1.0.0",
         "shex-examples": "^0.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "jsdom": "^30.0.1",
     "mocha": "^11.7.6",
     "nock": "^14.0.16",
-    "node-fetch": "^2.7.0",
     "nyc": "^18.0.0",
     "pre-commit": "^1.2.2",
     "shex-test": "github:shexSpec/shexTest#main",

--- a/packages/extension-map/bin/materialize
+++ b/packages/extension-map/bin/materialize
@@ -49,7 +49,7 @@ function abort(msg) {
       ]
     },
     {
-      content: "Project home: " + require('chalk').underline("https://github.com/shexSpec/shex.js")
+      content: "Project home: " + (process.stdout.isTTY ? "\u001b[4mhttps://github.com/shexSpec/shex.js\u001b[24m" : "https://github.com/shexSpec/shex.js")
     }
   ]));
   process.exit(1);

--- a/packages/extension-map/package.json
+++ b/packages/extension-map/package.json
@@ -40,7 +40,6 @@
     "@shexjs/util": "^1.0.0-alpha.30",
     "@shexjs/visitor": "^1.0.0-alpha.30",
     "@shexjs/webapp": "^1.0.0-alpha.30",
-    "chalk": "^4.1.2",
     "command-line-args": "^6.0.2",
     "command-line-usage": "^7.0.3",
     "n3": "^2.7.4",

--- a/packages/extension-map/test/shexmap-editors-smoke-test.js
+++ b/packages/extension-map/test/shexmap-editors-smoke-test.js
@@ -9,7 +9,7 @@ const TEST_browser = "TEST_browser" in process.env ? JSON.parse(process.env["TES
 const Fs = require("fs");
 const Path = require("path");
 const expect = require("chai").expect;
-const node_fetch = require("node-fetch");
+const node_fetch = globalThis.fetch;
 // jsdom's engines outpace the packages' own; required lazily under
 // TEST_browser (c.f. browser-test.js)
 let Harness, nock;

--- a/packages/extension-map/test/shexmap-worker-editors-smoke-test.js
+++ b/packages/extension-map/test/shexmap-worker-editors-smoke-test.js
@@ -11,7 +11,7 @@ const TEST_browser = "TEST_browser" in process.env ? JSON.parse(process.env["TES
 const Fs = require("fs");
 const Path = require("path");
 const expect = require("chai").expect;
-const node_fetch = require("node-fetch");
+const node_fetch = globalThis.fetch;
 // jsdom's engines outpace the packages' own; required lazily under
 // TEST_browser (c.f. browser-test.js)
 let Harness;

--- a/packages/extension-reduce/test/reduce-editors-smoke-test.js
+++ b/packages/extension-reduce/test/reduce-editors-smoke-test.js
@@ -14,7 +14,7 @@ const TEST_browser = "TEST_browser" in process.env ? JSON.parse(process.env["TES
 const Fs = require("fs");
 const Path = require("path");
 const expect = require("chai").expect;
-const node_fetch = require("node-fetch");
+const node_fetch = globalThis.fetch;
 let Harness;
 
 const [[GitRootServer]] = require("../../../tools/testServer")

--- a/packages/shex-cli/bin/json-to-shex
+++ b/packages/shex-cli/bin/json-to-shex
@@ -6,7 +6,7 @@ const ShExUtil = require("@shexjs/util");
 const N3 = require("n3");
 const ShExNode = require("@shexjs/node")({
   rdfjs: N3,
-  fetch: require('node-fetch'),
+  fetch: globalThis.fetch,
   jsonld: require('jsonld'),
 });
 const ExitCode = require('../lib/ExitCode')
@@ -41,7 +41,7 @@ function abort (msg, exitCode) {
       optionList: CommandLineOptions
     },
     {
-      content: "Project home: " + require('chalk').underline("https://github.com/shexSpec/shex.js")
+      content: "Project home: " + (process.stdout.isTTY ? "\u001b[4mhttps://github.com/shexSpec/shex.js\u001b[24m" : "https://github.com/shexSpec/shex.js")
     }
   ]));
   process.exit(exitCode);

--- a/packages/shex-cli/bin/shex-to-json
+++ b/packages/shex-cli/bin/shex-to-json
@@ -6,7 +6,7 @@ const ShExUtil = require("@shexjs/util");
 const N3 = require("n3");
 const ShExNode = require("@shexjs/node")({
   rdfjs: N3,
-  fetch: require('node-fetch'),
+  fetch: globalThis.fetch,
   jsonld: require('jsonld'),
 });
 const ExitCode = require('../lib/ExitCode')
@@ -42,7 +42,7 @@ function abort (msg, exitCode) {
       optionList: CommandLineOptions
     },
     {
-      content: "Project home: " + require('chalk').underline("https://github.com/shexSpec/shex.js")
+      content: "Project home: " + (process.stdout.isTTY ? "\u001b[4mhttps://github.com/shexSpec/shex.js\u001b[24m" : "https://github.com/shexSpec/shex.js")
     }
   ]));
   process.exit(exitCode);

--- a/packages/shex-cli/bin/shex-to-turtle
+++ b/packages/shex-cli/bin/shex-to-turtle
@@ -89,7 +89,7 @@ function abort (msg) {
       optionList: CommandLineOptions
     },
     {
-      content: "Project home: " + require('chalk').underline("https://github.com/shexSpec/shex.js")
+      content: "Project home: " + (process.stdout.isTTY ? "\u001b[4mhttps://github.com/shexSpec/shex.js\u001b[24m" : "https://github.com/shexSpec/shex.js")
     }
   ]));
   process.exit(1);

--- a/packages/shex-cli/package.json
+++ b/packages/shex-cli/package.json
@@ -43,7 +43,6 @@
     "@shexjs/validator": "^1.0.0-alpha.30",
     "@shexjs/visitor": "^1.0.0-alpha.30",
     "@shexjs/writer": "^1.0.0-alpha.30",
-    "chalk": "^4.1.2",
     "command-line-args": "^6.0.2",
     "command-line-usage": "^7.0.3",
     "js-yaml": "^5.4.1",
@@ -52,7 +51,6 @@
     "koa-body": "^6.0.1",
     "lezer-turtle": "^0.1.0",
     "n3": "^2.7.4",
-    "node-fetch": "^2.7.0",
     "shape-map": "^1.0.0",
     "shex-examples": "^0.1.0"
   },

--- a/packages/shex-cli/src/validate.ts
+++ b/packages/shex-cli/src/validate.ts
@@ -67,7 +67,7 @@ const N3 = require("n3");
 import ShExNodeCjsModule = require("@shexjs/node");
 const ShExNode = ShExNodeCjsModule({
   rdfjs: N3,
-  fetch: require('node-fetch'),
+  fetch: globalThis.fetch,
   jsonld: require('jsonld'),
 });
 const ExitCode: ExitCodes = require('../lib/ExitCode')
@@ -404,7 +404,7 @@ function abort (msg: string, exitCode: number): never {
       ]
     },
     {
-      content: "Project home: " + require('chalk').underline("https://github.com/shexSpec/shex.js")
+      content: "Project home: " + (process.stdout.isTTY ? "\u001b[4mhttps://github.com/shexSpec/shex.js\u001b[24m" : "https://github.com/shexSpec/shex.js")
     }
   ]));
   process.exit(exitCode);

--- a/packages/shex-cli/test/Server-test.js
+++ b/packages/shex-cli/test/Server-test.js
@@ -25,7 +25,7 @@ const Queue = require("timeout-promise-queue").PromiseQueue(25);
 
 const Fs = require("fs");
 const Path = require("path");
-const Fetch = require("node-fetch");
+const Fetch = globalThis.fetch;
 
 const manifestFile = "cli/manifest.json";
 

--- a/packages/shex-loader/README.md
+++ b/packages/shex-loader/README.md
@@ -38,7 +38,7 @@ const N3 = require('n3'); // used for graph API example
 // Initialize @shexjs/loader with implementations of APIs.
 const ShExLoader = require("@shexjs/loader")({
   rdfjs: N3,                    // use N3 as an RdfJs implementation
-  fetch: require('node-fetch'), // fetch implementation
+  fetch: globalThis.fetch, // fetch implementation
   jsonld: require('jsonld')     // JSON-LD (if you need it)
 });
 
@@ -168,7 +168,7 @@ Use `@shexjs/loader` directly:
 ```js
 const ShExIo = require("@shexjs/loader")({
   rdfjs: N3,
-  fetch: require('node-fetch')
+  fetch: globalThis.fetch
 });
 ```
 
@@ -176,7 +176,7 @@ Extend `@shexjs/loader` with jsonld and a non-standard jsonld document loader:
 ```js
 const ShExIo = require("@shexjs/loader")({
   rdfjs: N3,
-  fetch: require('node-fetch'),
+  fetch: globalThis.fetch,
   jsonld: require('jsonld'),
   jsonLdOptions: { documentLoader }
 });

--- a/packages/shex-loader/test/Loader-test.js
+++ b/packages/shex-loader/test/Loader-test.js
@@ -25,7 +25,7 @@ const [[SchemaServer, GitRootServer]] = require('../../../tools/testServer')
 // Initialize @shexjs/loader with implementations of APIs.
 const ShExLoader = require("..")({
   rdfjs: N3,                    // use N3 as an RdfJs implementation
-  fetch: require('node-fetch'), // fetch implementation
+  fetch: globalThis.fetch, // fetch implementation
   jsonld: require('jsonld')     // JSON-LD (if you need it)
 });
 

--- a/packages/shex-node/README.md
+++ b/packages/shex-node/README.md
@@ -30,7 +30,7 @@ Given a local `1dotOr2dot.shex` (say `PREFIX : <http://a.example/> :S1 { :p1 . |
 ``` js
 const ShExLoader = require("@shexjs/node")({
   rdfjs: require("n3"),          // an RDF/JS implementation
-  fetch: require("node-fetch"),  // for http(s): URLs
+  fetch: globalThis.fetch,  // for http(s): URLs
 });
 
 ShExLoader.load(

--- a/packages/shex-node/test/Node-test.js
+++ b/packages/shex-node/test/Node-test.js
@@ -16,7 +16,7 @@ const [[GitRootServer]] = require('../../../tools/testServer')
 // Initialize @shexjs/loader with implementations of APIs.
 const ShExLoader = require("..")({
   rdfjs: require('n3'),         // use N3 as an RdfJs implementation
-  fetch: require('node-fetch'), // fetch implementation
+  fetch: globalThis.fetch, // fetch implementation
   jsonld: require('jsonld')     // JSON-LD (if you need it)
 })
 

--- a/packages/shex-util/tools/common-test-infrastructure.js
+++ b/packages/shex-util/tools/common-test-infrastructure.js
@@ -14,7 +14,7 @@ const Path = require("path");
    >   // cwd: fromDir, // screws up absolutizeResults
    > });
    but instead wrap node-fetch and readFileSyn here: */
-const NodeFetch = require('node-fetch');
+const NodeFetch = globalThis.fetch;
 const ShExNode = {
   GET: function () {
     const [urlP, ...args] = arguments;

--- a/packages/shex-webapp/test/browser-test.js
+++ b/packages/shex-webapp/test/browser-test.js
@@ -24,7 +24,7 @@ const TESTS = [ // page and the labels on the top-most buttons on the manifest i
 let Fs = require('fs')
 let Path = require('path')
 let expect = require("chai").expect
-const node_fetch = require("node-fetch")
+const node_fetch = globalThis.fetch
 // jsdom's engines outpace the packages' own (e.g. jsdom 30 wants Node ≥ 22
 // while the libraries claim ≥ 18): required lazily under TEST_browser so the
 // other suites still run wherever the packages themselves do

--- a/packages/shex-webapp/test/editors-smoke-test.js
+++ b/packages/shex-webapp/test/editors-smoke-test.js
@@ -14,7 +14,7 @@ const TEST_browser = "TEST_browser" in process.env ? JSON.parse(process.env["TES
 const Fs = require("fs");
 const Path = require("path");
 const expect = require("chai").expect;
-const node_fetch = require("node-fetch");
+const node_fetch = globalThis.fetch;
 // jsdom's engines outpace the packages' own; required lazily under
 // TEST_browser (c.f. browser-test.js)
 let Harness;

--- a/packages/shex-webapp/test/harness.js
+++ b/packages/shex-webapp/test/harness.js
@@ -30,7 +30,7 @@
 
 const Fs = require("fs");
 const Path = require("path");
-const node_fetch = require("node-fetch");
+const node_fetch = globalThis.fetch;
 const jsdom = require("jsdom");
 const {makeWorkerClass} = require("./fakeWorker");
 

--- a/packages/shex-webapp/test/plugin-cross-origin-test.js
+++ b/packages/shex-webapp/test/plugin-cross-origin-test.js
@@ -17,7 +17,7 @@ const TEST_browser = "TEST_browser" in process.env ? JSON.parse(process.env["TES
 const Fs = require("fs");
 const Path = require("path");
 const expect = require("chai").expect;
-const node_fetch = require("node-fetch");
+const node_fetch = globalThis.fetch;
 let Harness;
 
 const ROOT = Path.join(__dirname, "../../..");

--- a/packages/shex-webapp/test/plugin-loading-smoke-test.js
+++ b/packages/shex-webapp/test/plugin-loading-smoke-test.js
@@ -17,7 +17,7 @@ const TEST_browser = "TEST_browser" in process.env ? JSON.parse(process.env["TES
 const Fs = require("fs");
 const Path = require("path");
 const expect = require("chai").expect;
-const node_fetch = require("node-fetch");
+const node_fetch = globalThis.fetch;
 let Harness;
 
 const [[GitRootServer]] = require("../../../tools/testServer")

--- a/packages/shex-webapp/test/serve-test.js
+++ b/packages/shex-webapp/test/serve-test.js
@@ -5,7 +5,7 @@
 
 const expect = require("chai").expect;
 const Path = require("path");
-const fetch = require("node-fetch");
+const fetch = globalThis.fetch;
 const {makeServer} = require("../lib/shex-serve");
 
 const repoRoot = Path.join(__dirname, "../../..");

--- a/packages/shex-webapp/test/worker-editors-smoke-test.js
+++ b/packages/shex-webapp/test/worker-editors-smoke-test.js
@@ -12,7 +12,7 @@ const TEST_browser = "TEST_browser" in process.env ? JSON.parse(process.env["TES
 const Fs = require("fs");
 const Path = require("path");
 const expect = require("chai").expect;
-const node_fetch = require("node-fetch");
+const node_fetch = globalThis.fetch;
 // jsdom's engines outpace the packages' own; required lazily under
 // TEST_browser (c.f. browser-test.js)
 let Harness;

--- a/packages/shex/README.md
+++ b/packages/shex/README.md
@@ -29,7 +29,7 @@ const node = "http://shex.io/examples/Issue1#Issue1"; // node in that data
 
 const N3 = require("n3");
 const ShExLoader = ShEx.Loader({                      // initialize with:
-  fetch: require("node-fetch"),                       //   fetch implementation
+  fetch: globalThis.fetch,                       //   fetch implementation
   rdfjs: N3,                                          //   RdfJs Turtle parser
 });
 


### PR DESCRIPTION
Resolves the `node-fetch` 2→3 and `chalk` 4→6 dependabot bumps — but not by taking the bumps. Both v3/v6 are **ESM-only**, so a CommonJS `require()` throws on **Node 18–20.18**, and this CLI's `engines` is `>=18`. Taking them would either break those Node versions or force a Node-floor bump. Instead, both are replaced with built-ins that work on every supported Node, and the dependencies are **removed**.

## node-fetch → global `fetch`

Node has had a global `fetch` since 18. It's a safe drop-in here: `@shexjs/loader` only ever calls the `fetch` option for **http(s)** (it resolves `data:` URIs itself and delegates `file:` to `@shexjs/node`), and Node's `fetch` tolerates being called as `config.fetch(url, opts)` (verified — no "Illegal invocation"). Changed:
- 3 product sites (`shex-cli/src/validate.ts`, `bin/json-to-shex`, `bin/shex-to-json`)
- the test harnesses (17 files) and the READMEs
- `node-fetch` removed from every `package.json`

## chalk → inline TTY-aware underline

`chalk` was used for exactly one thing: underlining the project URL in `--help`. Replaced with `process.stdout.isTTY ? "\x1b[4m"+url+"\x1b[24m" : url` (raw ANSI when attached to a terminal, plain otherwise). `util.styleText` would've been the built-in, but it needs Node 20.12+, so the two-branch inline is the portable equivalent. `chalk` removed from every `package.json`.

## Verification

- Full gated suite (cli + browser + server): **6149 passing / 0 failing**.
- `lint` passes.
- `--help` piped shows a plain URL (no stray ANSI); on a TTY the URL underlines.
- Net effect: **−2 dependencies**, 33 insertions / 37 deletions.

Closes the intent of the node-fetch and chalk dependabot PRs (they can be closed as replaced-by-built-ins). If you'd rather actually adopt v3/v6 and raise the Node floor to 20.19+ instead, say so and I'll swap the approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBCrywES6wuj3RHqExHA7S
