### PR TITLE
deps: bump rdf-data-factory 1.1.3 → 2.0.2 (major)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13355,6 +13355,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
       "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "dev": true,
       "dependencies": {
         "@rdfjs/types": "^1.0.0"
       }
@@ -16675,7 +16676,7 @@
         "command-line-args": "^6.0.2",
         "command-line-usage": "^7.0.3",
         "n3": "^2.7.4",
-        "rdf-data-factory": "^1.1.2"
+        "rdf-data-factory": "^2.0.2"
       },
       "bin": {
         "shexmap-debug": "bin/shexmap-debug",
@@ -16705,7 +16706,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
       "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -16745,6 +16745,19 @@
       },
       "engines": {
         "node": ">=12.0"
+      }
+    },
+    "packages/extension-map/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
     "packages/extension-map/node_modules/readable-stream": {
@@ -17795,7 +17808,7 @@
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
         "@types/shexj": "^2.1.7",
-        "rdf-data-factory": "^1.1.2",
+        "rdf-data-factory": "^2.0.2",
         "relativize-url": "^0.1.0"
       },
       "engines": {
@@ -17809,6 +17822,19 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "packages/shex-term/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
     "packages/shex-util": {

--- a/packages/extension-map/package.json
+++ b/packages/extension-map/package.json
@@ -43,7 +43,7 @@
     "command-line-args": "^6.0.2",
     "command-line-usage": "^7.0.3",
     "n3": "^2.7.4",
-    "rdf-data-factory": "^1.1.2"
+    "rdf-data-factory": "^2.0.2"
   },
   "devDependencies": {
     "@rdfjs/types": "^2.0.1",

--- a/packages/shex-term/package.json
+++ b/packages/shex-term/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@rdfjs/types": "^2.0.1",
     "@types/shexj": "^2.1.7",
-    "rdf-data-factory": "^1.1.2",
+    "rdf-data-factory": "^2.0.2",
     "relativize-url": "^0.1.0"
   },
   "scripts": {


### PR DESCRIPTION
Resolves #428 (dependabot's rdf-data-factory major).

Our two direct consumers — **extension-map** and **@shexjs/term** — move from `^1.1.2` to `^2.0.2`, aligning with `@rdfjs/types` 2 and the `rdf-data-factory` 2 that **Comunica 5 already pulls in throughout the tree**.

- Compiles with **zero type errors and byte-identical generated output** — no source changes needed (the `@rdfjs/types` 2 `DataFactory` adaptation already landed on main).
- Third-party transitives still pinning `^1.x` (sparqljs, rdf-parse, some rdfjs utils) keep a deduped `1.1.3` alongside — the same end state #428 would produce, since dependabot bumps only the direct declarations.

Superseding #428 with this branch (verified against current main after the other dep merges). Once green I'll merge and close #428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBCrywES6wuj3RHqExHA7S