### PR TITLE
webapp: add a TinyURL "shorten" link beside Permalink

### DIFF
--- a/packages/shex-webapp/doc/ShExBaseApp-layout.js
+++ b/packages/shex-webapp/doc/ShExBaseApp-layout.js
@@ -172,9 +172,10 @@ mixin(ShExBaseApp, {
                 const left = bottonBBox.right - bottonBBox.width; // - controlsBBox.width;
                 $("#controls").css("top", bottonBBox.bottom).css("left", left);
             }
-            $("#permalink a").removeAttr("href"); // can't click until ready
+            $("#permalinkAnchor").removeAttr("href"); // can't click until ready
             const permalink = await this.getPermalink();
-            $("#permalink a").attr("href", permalink);
+            $("#permalinkAnchor").attr("href", permalink);
+            $("#shortPermalink").attr("href", "").text(""); // a fresh permalink outdates any short link
         }
     },
     toggleControlsArrow(which) {

--- a/packages/shex-webapp/doc/ShExBaseApp-links.js
+++ b/packages/shex-webapp/doc/ShExBaseApp-links.js
@@ -180,6 +180,46 @@ mixin(ShExBaseApp, {
         const s = parms.join("&");
         return location.origin + location.pathname + "?" + s;
     },
+    /** Menu → "shorten": swap the (often very long) permalink for a TinyURL
+     * short link.  TinyURL's keyless api-create.php is CORS-enabled and hands
+     * back the short URL as plain text, so no server of our own is needed; we
+     * show it beside Permalink and copy it to the clipboard.  TinyURL answers
+     * 200 with an error string rather than an HTTP error when it refuses a URL
+     * (an over-long one, say), so we vet the body, not just the status, and on
+     * any failure keep the long link -- for a link too big to shorten, "Create
+     * Gist" is the path that scales. */
+    async shortenPermalink(evt) {
+        if (evt)
+            evt.preventDefault();
+        const $btn = $("#shortenPermalink"), $out = $("#shortPermalink");
+        // the menu builds the permalink as it opens; build one now in case the
+        // click somehow beat that
+        const long = $("#permalinkAnchor").attr("href") || await this.getPermalink();
+        $btn.text("shortening…");
+        $out.attr("href", "").text("");
+        try {
+            const resp = await fetch("https://tinyurl.com/api-create.php?url=" +
+                encodeURIComponent(long));
+            const body = (await resp.text()).trim();
+            if (!resp.ok || !/^https?:\/\//.test(body))
+                throw new Error(body || ("HTTP " + resp.status));
+            $out.attr("href", body).text(body);
+            try {
+                await navigator.clipboard.writeText(body);
+                $btn.text("copied ✓");
+            }
+            catch (e) {
+                // clipboard wants a secure context and permission; the link shows regardless
+                $btn.text("shortened");
+            }
+        }
+        catch (e) {
+            $btn.text("shorten failed").attr("title", "TinyURL: " + e.message);
+            console.warn("TinyURL shorten failed:", e);
+        }
+        window.setTimeout(() => $btn.text("shorten").attr("title", "Shorten this link with TinyURL"), 2500);
+        return null;
+    },
     /** Menu → "Create Gist": publish the inputs this app registered with a
      * manifest descriptor in its QueryParams (shex-simple: schema, data,
      * queryMap; shexmap adds staticVars, outputSchema, outputShapeMap) as a

--- a/packages/shex-webapp/doc/ShExBaseApp.js
+++ b/packages/shex-webapp/doc/ShExBaseApp.js
@@ -281,6 +281,7 @@ class ShExBaseApp {
             return false;
         });
         $("#download-results-button").on("click", this.downloadResults.bind(this));
+        $("#shortenPermalink").on("click", (evt) => { this.track(this.shortenPermalink(evt)); });
         $("#createGist").on("click", (evt) => { this.track(this.createGist(evt)); });
         $("#updateGist").on("click", (evt) => { this.track(this.updateGist(evt)); });
         $("#loadForm").dialog({

--- a/packages/shex-webapp/doc/shex-simple.html
+++ b/packages/shex-webapp/doc/shex-simple.html
@@ -70,7 +70,7 @@
               <li class="        "><hr/></li>
               <li class="menuitem"><input type="checkbox" id="skipCycleCheck" checked/><label for="skipCycleCheck">skip cycle check</label></li>
               <li class="menuitem"><input type="checkbox" id="ignoreClosed"/><label for="ignoreClosed">ignore closed-ness of shapes</label></li>
-              <li class="menuitem" id="permalink"><a>Permalink</a></li>
+              <li class="menuitem" id="permalink"><a id="permalinkAnchor">Permalink</a> <a id="shortenPermalink" title="Shorten this link with TinyURL" style="cursor: pointer;">shorten</a> <a id="shortPermalink" target="_blank" rel="noopener" style="word-break: break-all;"></a></li>
               <li class="menuitem"><span id="createGist"><a>Create</a></span><span id="updateGist" style="display:none" title="update the gist this page's manifest was loaded from">/<a>Update</a></span> Gist |
                 <a id="gistToken" title="get this token" href="https://github.com/settings/tokens/new?scopes=gist&amp;description=shex-simple" target="_blank">get token</a>
                 <a id="gistInstructions" style="float:right">help</a>

--- a/packages/shex-webapp/src/app/ShExBaseApp-layout.ts
+++ b/packages/shex-webapp/src/app/ShExBaseApp-layout.ts
@@ -196,9 +196,10 @@ mixin(ShExBaseApp, {
         const left = bottonBBox.right - bottonBBox.width; // - controlsBBox.width;
         $("#controls").css("top", bottonBBox.bottom).css("left", left);
       }
-      $("#permalink a").removeAttr("href"); // can't click until ready
+      $("#permalinkAnchor").removeAttr("href"); // can't click until ready
       const permalink = await this.getPermalink();
-      $("#permalink a").attr("href", permalink);
+      $("#permalinkAnchor").attr("href", permalink);
+      $("#shortPermalink").attr("href", "").text(""); // a fresh permalink outdates any short link
     }
   },
 

--- a/packages/shex-webapp/src/app/ShExBaseApp-links.ts
+++ b/packages/shex-webapp/src/app/ShExBaseApp-links.ts
@@ -13,6 +13,7 @@ interface ShExBaseApp {
   loadSearchParameters (): Promise<any>;
   parseQueryString (query: any): any;
   getPermalink (): Promise<string>;
+  shortenPermalink (evt: any): Promise<any>;
   createGist (evt: any): Promise<any>;
   updateGist (evt: any): Promise<any>;
   getGistToken (): string | null;
@@ -196,6 +197,46 @@ parseQueryString (query: any) {
     }, []));
     const s = parms.join("&");
     return location.origin + location.pathname + "?" + s;
+  },
+
+  /** Menu → "shorten": swap the (often very long) permalink for a TinyURL
+   * short link.  TinyURL's keyless api-create.php is CORS-enabled and hands
+   * back the short URL as plain text, so no server of our own is needed; we
+   * show it beside Permalink and copy it to the clipboard.  TinyURL answers
+   * 200 with an error string rather than an HTTP error when it refuses a URL
+   * (an over-long one, say), so we vet the body, not just the status, and on
+   * any failure keep the long link -- for a link too big to shorten, "Create
+   * Gist" is the path that scales. */
+  async shortenPermalink (evt: any) {
+    if (evt) evt.preventDefault();
+    const $btn = $("#shortenPermalink"), $out = $("#shortPermalink");
+    // the menu builds the permalink as it opens; build one now in case the
+    // click somehow beat that
+    const long = $("#permalinkAnchor").attr("href") || await this.getPermalink();
+    $btn.text("shortening…");
+    $out.attr("href", "").text("");
+    try {
+      const resp = await fetch("https://tinyurl.com/api-create.php?url=" +
+                               encodeURIComponent(long));
+      const body = (await resp.text()).trim();
+      if (!resp.ok || !/^https?:\/\//.test(body))
+        throw new Error(body || ("HTTP " + resp.status));
+      $out.attr("href", body).text(body);
+      try {
+        await navigator.clipboard.writeText(body);
+        $btn.text("copied ✓");
+      } catch (e) {
+        // clipboard wants a secure context and permission; the link shows regardless
+        $btn.text("shortened");
+      }
+    } catch (e: any) {
+      $btn.text("shorten failed").attr("title", "TinyURL: " + e.message);
+      console.warn("TinyURL shorten failed:", e);
+    }
+    window.setTimeout(
+      () => $btn.text("shorten").attr("title", "Shorten this link with TinyURL"),
+      2500);
+    return null;
   },
 
   /** Menu → "Create Gist": publish the inputs this app registered with a

--- a/packages/shex-webapp/src/app/ShExBaseApp.ts
+++ b/packages/shex-webapp/src/app/ShExBaseApp.ts
@@ -336,6 +336,7 @@ onDataLoad (): void {
       return false;
     });
     $("#download-results-button").on("click", this.downloadResults.bind(this));
+    $("#shortenPermalink").on("click", (evt: any) => { this.track(this.shortenPermalink(evt)); });
     $("#createGist").on("click", (evt: any) => { this.track(this.createGist(evt)); });
     $("#updateGist").on("click", (evt: any) => { this.track(this.updateGist(evt)); });
 


### PR DESCRIPTION
Adds a **shorten** action next to the demo app's Permalink menu item.

## Why
The permalink encodes the whole on-screen state (schema, data, query map, loaded plugins) in the query string, so it's routinely too long to paste into a chat or a slide. This gives a one-click short link.

## How
- A `shorten` link sits beside Permalink; clicking it sends the current permalink to **TinyURL's keyless `api-create.php`**, which is **CORS-enabled** (verified: it reflects the request Origin) and returns the short URL as plain text — so no server of our own is needed.
- On success the short link is shown beside Permalink (new tab, selectable) **and copied to the clipboard**.
- TinyURL answers `200` with an error *string* (not an HTTP error) when it refuses a URL — e.g. an over-long one — so the handler **vets the body**, not just the status, and on any failure keeps the long link. For a link too big to shorten, **Create Gist** remains the path that scales.
- Chose TinyURL because it's what makes sense here: keyless, CORS-enabled, plain-text response, and no token to leak in a static client-side page. (is.gd sent no CORS header in testing, so it would be blocked from the browser.)

## Notes
- The permalink's own anchor gains an id (`#permalinkAnchor`) so the app targets it specifically now that the menu item holds three anchors; the smoke tests read `$("#permalink a")` (the first anchor) and are unaffected — both permalink smoke tests pass.
- `doc/*.js` is the `tsconfig.app.json` build of `src/app/*.ts`, regenerated in this commit.

## Verified
- End-to-end against the real service: a 429-char sample permalink → `tinyurl.com/29gd2ssb`, which 301-redirects back to the permalink; the body-vetting logic accepts it.
- Both permalink smoke tests green; full pre-commit suite green (5769).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBCrywES6wuj3RHqExHA7S
