### PR TITLE
webapp: make the shortened link visible + stop href="" reloading the page

### DIFF
--- a/packages/shex-webapp/doc/ShExBaseApp-layout.js
+++ b/packages/shex-webapp/doc/ShExBaseApp-layout.js
@@ -175,7 +175,10 @@ mixin(ShExBaseApp, {
             $("#permalinkAnchor").removeAttr("href"); // can't click until ready
             const permalink = await this.getPermalink();
             $("#permalinkAnchor").attr("href", permalink);
-            $("#shortPermalink").attr("href", "").text(""); // a fresh permalink outdates any short link
+            // a fresh permalink outdates any short link (removeAttr, never href="",
+            // which would make the anchor reload the page)
+            $("#shortPermalinkRow").hide();
+            $("#shortPermalink").removeAttr("href").text("");
         }
     },
     toggleControlsArrow(which) {

--- a/packages/shex-webapp/doc/ShExBaseApp-links.js
+++ b/packages/shex-webapp/doc/ShExBaseApp-links.js
@@ -191,33 +191,41 @@ mixin(ShExBaseApp, {
     async shortenPermalink(evt) {
         if (evt)
             evt.preventDefault();
-        const $btn = $("#shortenPermalink"), $out = $("#shortPermalink");
+        const $btn = $("#shortenPermalink"), $out = $("#shortPermalink"), $row = $("#shortPermalinkRow");
+        const label = $btn.text() || "shorten";
         // the menu builds the permalink as it opens; build one now in case the
         // click somehow beat that
         const long = $("#permalinkAnchor").attr("href") || await this.getPermalink();
-        $btn.text("shortening…");
-        $out.attr("href", "").text("");
+        $btn.prop("disabled", true).text("shortening…");
+        $row.hide();
+        $out.removeAttr("href").text("");
         try {
             const resp = await fetch("https://tinyurl.com/api-create.php?url=" +
                 encodeURIComponent(long));
             const body = (await resp.text()).trim();
+            // TinyURL answers 200 with an error string (not an HTTP error) when it
+            // refuses a URL -- an over-long one, say -- so vet the body, not the status
             if (!resp.ok || !/^https?:\/\//.test(body))
                 throw new Error(body || ("HTTP " + resp.status));
+            // show it beside Permalink, log it (a place to copy it from), and put it
+            // on the clipboard
             $out.attr("href", body).text(body);
+            $row.show();
+            console.log("TinyURL short link: " + body);
+            let copied = false;
             try {
                 await navigator.clipboard.writeText(body);
-                $btn.text("copied ✓");
+                copied = true;
             }
-            catch (e) {
-                // clipboard wants a secure context and permission; the link shows regardless
-                $btn.text("shortened");
-            }
+            catch (e) { /* clipboard needs a secure context + permission; link still shows */ }
+            $btn.text(copied ? "copied ✓" : "shortened");
         }
         catch (e) {
             $btn.text("shorten failed").attr("title", "TinyURL: " + e.message);
             console.warn("TinyURL shorten failed:", e);
         }
-        window.setTimeout(() => $btn.text("shorten").attr("title", "Shorten this link with TinyURL"), 2500);
+        window.setTimeout(() => $btn.prop("disabled", false).text(label)
+            .attr("title", "Shorten this link with TinyURL"), 2500);
         return null;
     },
     /** Menu → "Create Gist": publish the inputs this app registered with a

--- a/packages/shex-webapp/doc/shex-simple.html
+++ b/packages/shex-webapp/doc/shex-simple.html
@@ -70,7 +70,7 @@
               <li class="        "><hr/></li>
               <li class="menuitem"><input type="checkbox" id="skipCycleCheck" checked/><label for="skipCycleCheck">skip cycle check</label></li>
               <li class="menuitem"><input type="checkbox" id="ignoreClosed"/><label for="ignoreClosed">ignore closed-ness of shapes</label></li>
-              <li class="menuitem" id="permalink"><a id="permalinkAnchor">Permalink</a> <a id="shortenPermalink" title="Shorten this link with TinyURL" style="cursor: pointer;">shorten</a> <a id="shortPermalink" target="_blank" rel="noopener" style="word-break: break-all;"></a></li>
+              <li class="menuitem" id="permalink"><a id="permalinkAnchor">Permalink</a> <button type="button" id="shortenPermalink" title="Shorten this link with TinyURL" style="cursor: pointer;">shorten</button><span id="shortPermalinkRow" style="display: none;"> &rarr; <a id="shortPermalink" target="_blank" rel="noopener" style="word-break: break-all;"></a></span></li>
               <li class="menuitem"><span id="createGist"><a>Create</a></span><span id="updateGist" style="display:none" title="update the gist this page's manifest was loaded from">/<a>Update</a></span> Gist |
                 <a id="gistToken" title="get this token" href="https://github.com/settings/tokens/new?scopes=gist&amp;description=shex-simple" target="_blank">get token</a>
                 <a id="gistInstructions" style="float:right">help</a>

--- a/packages/shex-webapp/src/app/ShExBaseApp-layout.ts
+++ b/packages/shex-webapp/src/app/ShExBaseApp-layout.ts
@@ -199,7 +199,10 @@ mixin(ShExBaseApp, {
       $("#permalinkAnchor").removeAttr("href"); // can't click until ready
       const permalink = await this.getPermalink();
       $("#permalinkAnchor").attr("href", permalink);
-      $("#shortPermalink").attr("href", "").text(""); // a fresh permalink outdates any short link
+      // a fresh permalink outdates any short link (removeAttr, never href="",
+      // which would make the anchor reload the page)
+      $("#shortPermalinkRow").hide();
+      $("#shortPermalink").removeAttr("href").text("");
     }
   },
 

--- a/packages/shex-webapp/src/app/ShExBaseApp-links.ts
+++ b/packages/shex-webapp/src/app/ShExBaseApp-links.ts
@@ -209,32 +209,39 @@ parseQueryString (query: any) {
    * Gist" is the path that scales. */
   async shortenPermalink (evt: any) {
     if (evt) evt.preventDefault();
-    const $btn = $("#shortenPermalink"), $out = $("#shortPermalink");
+    const $btn = $("#shortenPermalink"), $out = $("#shortPermalink"),
+          $row = $("#shortPermalinkRow");
+    const label = $btn.text() || "shorten";
     // the menu builds the permalink as it opens; build one now in case the
     // click somehow beat that
     const long = $("#permalinkAnchor").attr("href") || await this.getPermalink();
-    $btn.text("shortening…");
-    $out.attr("href", "").text("");
+    $btn.prop("disabled", true).text("shortening…");
+    $row.hide();
+    $out.removeAttr("href").text("");
     try {
       const resp = await fetch("https://tinyurl.com/api-create.php?url=" +
                                encodeURIComponent(long));
       const body = (await resp.text()).trim();
+      // TinyURL answers 200 with an error string (not an HTTP error) when it
+      // refuses a URL -- an over-long one, say -- so vet the body, not the status
       if (!resp.ok || !/^https?:\/\//.test(body))
         throw new Error(body || ("HTTP " + resp.status));
+      // show it beside Permalink, log it (a place to copy it from), and put it
+      // on the clipboard
       $out.attr("href", body).text(body);
-      try {
-        await navigator.clipboard.writeText(body);
-        $btn.text("copied ✓");
-      } catch (e) {
-        // clipboard wants a secure context and permission; the link shows regardless
-        $btn.text("shortened");
-      }
+      $row.show();
+      console.log("TinyURL short link: " + body);
+      let copied = false;
+      try { await navigator.clipboard.writeText(body); copied = true; }
+      catch (e) { /* clipboard needs a secure context + permission; link still shows */ }
+      $btn.text(copied ? "copied ✓" : "shortened");
     } catch (e: any) {
       $btn.text("shorten failed").attr("title", "TinyURL: " + e.message);
       console.warn("TinyURL shorten failed:", e);
     }
     window.setTimeout(
-      () => $btn.text("shorten").attr("title", "Shorten this link with TinyURL"),
+      () => $btn.prop("disabled", false).text(label)
+              .attr("title", "Shorten this link with TinyURL"),
       2500);
     return null;
   },


### PR DESCRIPTION
Follow-up to #448 (merged), fixing two issues found in testing.

**1. The short link was invisible.** The success path logged nothing and the result was an empty inline `<a>` buried in the menu — easy to miss entirely.

**2. `href=""` reloaded the page.** The trigger was an `<a>`, and the output anchor was cleared with `href=""`; an `<a href="">` resolves to the current URL, so clicking it navigated/reloaded ("pushed a location").

## Fix
- The **shorten** trigger is now a real `<button type="button">` — it can never navigate.
- The short link is cleared with `removeAttr("href")`, **never** `href=""`.
- On success the link is now surfaced in three places: a **revealed row beside Permalink** (`→ https://tinyurl.com/…`, opens in a new tab), the **console** (`TinyURL short link: …`), and the **clipboard**. The button disables while the request is in flight and restores its label afterward.

## Verified
- Confirmed working in the app by the maintainer.
- Both permalink smoke tests pass; full pre-commit suite green (5769).
- `doc/*.js` regenerated from `src/app/*.ts` via `tsconfig.app.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBCrywES6wuj3RHqExHA7S