### PR TITLE
refactor: rename ShExWriter → ShExCWriter (it writes ShExC)

### DIFF
--- a/packages/shex-cli/src/validate.ts
+++ b/packages/shex-cli/src/validate.ts
@@ -60,7 +60,7 @@ const QueryDbModules: QueryDbModule[] = [
 ];
 import * as ShExTerm from "@shexjs/term";
 import * as ShExParser from "@shexjs/parser";
-import ShExWriter = require("@shexjs/writer"); // for verbose output
+import ShExCWriter = require("@shexjs/writer"); // for verbose output
 import {ShExValidator, resultMapToShapeExprTest} from "@shexjs/validator";
 import ShapeMap = require("shape-map");
 const N3 = require("n3");
@@ -553,7 +553,7 @@ async function findNodesAndValidate (loaded: any, parms: any, options: any, sche
     let tz = shapeMap.map((p: any) => { return p.node + " AS " + p.shape; });
     tz = tz.length > 1 ? JSON.stringify(tz) : tz[0];
     let w: string | undefined;
-    new ShExWriter({simplifyParentheses: false }).
+    new ShExCWriter({simplifyParentheses: false }).
       writeSchema(loaded.schema, function (error: any, text: string) {
         if (error) throw error;
         else w = text;

--- a/packages/shex-cli/test/Parser-Writer-test.js
+++ b/packages/shex-cli/test/Parser-Writer-test.js
@@ -12,7 +12,7 @@ const ShExUtil = require("@shexjs/util");
 const {ShExVisitor} = require("@shexjs/visitor");
 const { ctor: RdfJsDb } = require('@shexjs/neighborhood-rdfjs');
 const {ShExValidator} = require("@shexjs/validator");
-const ShExWriter = require("@shexjs/writer");
+const ShExCWriter = require("@shexjs/writer");
 const N3 = require("n3");
 const ShExNode = require("@shexjs/node")({
   rdfjs: N3,
@@ -210,7 +210,7 @@ describe("Parser-Writer-test", function () {
 
         it("should write '" + jsonSchemaFile + "' and parse to the same structure.", function () {
           let w;
-          new ShExWriter({simplifyParentheses: false, base: meta.base, prefixes: meta.prefixes}).
+          new ShExCWriter({simplifyParentheses: false, base: meta.base, prefixes: meta.prefixes}).
             writeSchema(abstractSyntax, function (error, text, prefixes) {
               if (error) throw error;
               else w = text;
@@ -225,7 +225,7 @@ describe("Parser-Writer-test", function () {
 
         it ("should write '" + jsonSchemaFile + "' with as few ()s as possible.", function () {
           let w;
-          new ShExWriter({simplifyParentheses: true }).
+          new ShExCWriter({simplifyParentheses: true }).
             writeSchema(abstractSyntax, function (error, text, prefixes) {
               if (error) throw error;
               else w = text;

--- a/packages/shex-util/src/error-messages.ts
+++ b/packages/shex-util/src/error-messages.ts
@@ -18,7 +18,7 @@
 
 import type * as ShExJ from "shexj";
 
-const ShExWriter = require("@shexjs/writer");
+const ShExCWriter = require("@shexjs/writer");
 
 /** where in a sentence a term stands, so a host can spell it accordingly */
 export type TermRole = "subject" | "predicate" | "object" | "node" | "property" | "shape";
@@ -157,7 +157,7 @@ export function shexcFragment (expr: any, prefixes?: { [prefix: string]: string 
   if (typeof expr === "string")            // a shape reference
     return "@" + iriText(expr, prefixes, base);
   try {
-    const writer = new ShExWriter({simplifyParentheses: false, prefixes: prefixes || {}});
+    const writer = new ShExCWriter({simplifyParentheses: false, prefixes: prefixes || {}});
     const said = writer.writeShapeExpr(expr);
     return typeof said === "string" ? said.trim() : "";
   } catch (e) {

--- a/packages/shex-writer/src/shex-writer.ts
+++ b/packages/shex-writer/src/shex-writer.ts
@@ -1,4 +1,4 @@
-// **ShExWriter** writes ShEx documents.
+// **ShExCWriter** writes ShEx documents.
 import * as ShExJ from 'shexj';
 
 const RelativizeIri = require("relativize-url").relativize;
@@ -22,7 +22,7 @@ const nodeKinds: { [nodeKind: string]: string } = {
   'nonliteral': "NONLITERAL"
 };
 
-/** stream (e.g. process.stdout) accepted by the ShExWriter constructor */
+/** stream (e.g. process.stdout) accepted by the ShExCWriter constructor */
 interface WritableStream {
   write (chunk: string, encoding?: string | ((error?: any, result?: any) => void), done?: (error?: any, result?: any) => void): any;
   end (done?: ((error?: any, result?: any) => void) | null): any;
@@ -30,7 +30,7 @@ interface WritableStream {
 
 type DoneCallback = (error?: any, result?: any) => void;
 
-interface ShExWriterOptions {
+interface ShExCWriterOptions {
   /** base IRI against which output IRIs are relativized */
   base?: string | null;
   /** prefixes to declare and use for prefixed names */
@@ -47,7 +47,7 @@ interface ShExWriterOptions {
 
 type Piece = string | number;
 
-class ShExWriter {
+class ShExCWriter {
   _outputStream: WritableStream;
   _endStream: boolean;
   _prefixIRIs: { [iri: string]: string };
@@ -58,10 +58,10 @@ class ShExWriter {
   // ### `_prefixRegex` matches a prefixed name or IRI that begins with one of the added prefixes
   _prefixRegex: RegExp = /$0^/;
 
-  constructor (outputStream?: WritableStream | ShExWriterOptions | null, options?: ShExWriterOptions) {
+  constructor (outputStream?: WritableStream | ShExCWriterOptions | null, options?: ShExCWriterOptions) {
     // Shift arguments if the first argument is not a stream
     if (outputStream && typeof (outputStream as WritableStream).write !== 'function')
-      options = outputStream as ShExWriterOptions, outputStream = null;
+      options = outputStream as ShExCWriterOptions, outputStream = null;
     options = options || {};
 
     // If no output stream given, send the output as string through the end callback
@@ -97,52 +97,52 @@ class ShExWriter {
 
   // ### `_writeSchema` writes the shape to the output stream
   _writeSchema (schema: ShExJ.Schema & { _prefixes?: any, _base?: string | null }, done?: DoneCallback) {
-    const _ShExWriter = this;
+    const _ShExCWriter = this;
     this._expect(schema, "type", "Schema");
-    _ShExWriter.addPrefixes(schema._prefixes);
+    _ShExCWriter.addPrefixes(schema._prefixes);
     if (schema._base)
-      _ShExWriter._baseIRI = schema._base;
+      _ShExCWriter._baseIRI = schema._base;
 
-    if (_ShExWriter._baseIRI)
-      _ShExWriter._write("BASE <" + _ShExWriter._baseIRI + ">\n"); // don't use _encodeIriOrBlankNode()
+    if (_ShExCWriter._baseIRI)
+      _ShExCWriter._write("BASE <" + _ShExCWriter._baseIRI + ">\n"); // don't use _encodeIriOrBlankNode()
 
     if (schema.imports)
       schema.imports.forEach(function (imp) {
-        _ShExWriter._write("IMPORT " + _ShExWriter._encodeIriOrBlankNode(imp) + "\n");
+        _ShExCWriter._write("IMPORT " + _ShExCWriter._encodeIriOrBlankNode(imp) + "\n");
       });
     if (schema.startActs)
       schema.startActs.forEach(function (act) {
-        _ShExWriter._expect(act, "type", "SemAct");
-        _ShExWriter._write(" %"+
-                           _ShExWriter._encodePredicate(act.name)+
+        _ShExCWriter._expect(act, "type", "SemAct");
+        _ShExCWriter._write(" %"+
+                           _ShExCWriter._encodePredicate(act.name)+
                            ("code" in act ? "{"+escapeCode(act.code!)+"%"+"}" : "%"));
       });
     if (schema.start)
-      _ShExWriter._write("START = " + _ShExWriter._writeShapeExpr(schema.start, done, true, 0).join('') + "\n")
+      _ShExCWriter._write("START = " + _ShExCWriter._writeShapeExpr(schema.start, done, true, 0).join('') + "\n")
     if ("shapes" in schema)
       schema.shapes!.forEach(function (shapeDecl) {
         // `done` reports serialization errors; it is not a write-completion
         // callback, which would invoke it (argument-less) per flushed chunk
-        _ShExWriter._write(
-          _ShExWriter._writeShapeDecl(shapeDecl, done, true, 0).join("")+"\n"
+        _ShExCWriter._write(
+          _ShExCWriter._writeShapeDecl(shapeDecl, done, true, 0).join("")+"\n"
         );
       })
   }
 
   _writeShapeDecl (shapeDecl: ShExJ.ShapeDecl, done?: DoneCallback, _forceBraces?: boolean, _parentPrec?: number): Piece[] {
-    const _ShExWriter = this;
+    const _ShExCWriter = this;
     const pieces: Piece[] = [];
     if (shapeDecl.abstract)
       pieces.push("ABSTRACT ");
-    pieces.push(_ShExWriter._encodeShapeName(shapeDecl.id, false), " ");
-    return pieces.concat(_ShExWriter._writeShapeExpr(shapeDecl.shapeExpr, done, true, 0));
+    pieces.push(_ShExCWriter._encodeShapeName(shapeDecl.id, false), " ");
+    return pieces.concat(_ShExCWriter._writeShapeExpr(shapeDecl.shapeExpr, done, true, 0));
   }
 
   _writeShapeExpr (shapeExpr: ShExJ.shapeExprOrRef, done?: DoneCallback, forceBraces?: boolean, parentPrec: number = 0): Piece[] {
-    const _ShExWriter = this;
+    const _ShExCWriter = this;
     const pieces: Piece[] = [];
     if (typeof shapeExpr === "string") // ShapeRef
-      pieces.push("@", _ShExWriter._encodeShapeName(shapeExpr));
+      pieces.push("@", _ShExCWriter._encodeShapeName(shapeExpr));
     // !!! []s for precedence!
     else if (shapeExpr.type === "ShapeExternal")
       pieces.push("EXTERNAL");
@@ -189,7 +189,7 @@ class ShExWriter {
           }
           lastAndElided = elideAnd;
         }
-        [].push.apply(pieces, _ShExWriter._writeShapeExpr(expr, done, false, 3) as never[]);
+        [].push.apply(pieces, _ShExCWriter._writeShapeExpr(expr, done, false, 3) as never[]);
       });
       if (parentPrec >= 3)
         pieces.push(")");
@@ -199,7 +199,7 @@ class ShExWriter {
       shapeExpr.shapeExprs.forEach(function (expr, ord) {
         if (ord > 0)
           pieces.push(" OR ");
-        [].push.apply(pieces, _ShExWriter._writeShapeExpr(expr, done, forceBraces, 2) as never[]);
+        [].push.apply(pieces, _ShExCWriter._writeShapeExpr(expr, done, forceBraces, 2) as never[]);
       });
       if (parentPrec >= 2)
         pieces.push(")");
@@ -207,13 +207,13 @@ class ShExWriter {
       if (parentPrec >= 4)
         pieces.push("(");
       pieces.push("NOT ");
-      [].push.apply(pieces, _ShExWriter._writeShapeExpr(shapeExpr.shapeExpr, done, forceBraces, 4) as never[]);
+      [].push.apply(pieces, _ShExCWriter._writeShapeExpr(shapeExpr.shapeExpr, done, forceBraces, 4) as never[]);
       if (parentPrec >= 4)
         pieces.push(")");
     } else if (shapeExpr.type === "Shape") {
-      [].push.apply(pieces, _ShExWriter._writeShape(shapeExpr, done, forceBraces) as never[]);
+      [].push.apply(pieces, _ShExCWriter._writeShape(shapeExpr, done, forceBraces) as never[]);
     } else if (shapeExpr.type === "NodeConstraint") {
-      [].push.apply(pieces, _ShExWriter._writeNodeConstraint(shapeExpr, done) as never[]);
+      [].push.apply(pieces, _ShExCWriter._writeNodeConstraint(shapeExpr, done) as never[]);
     } else
       throw Error("expected Shape{,And,Or,Ref} or NodeConstraint in " + JSON.stringify(shapeExpr));
     return pieces;
@@ -221,7 +221,7 @@ class ShExWriter {
 
   // ### `_writeShape` writes the shape to the output stream
   _writeShape (shape: ShExJ.Shape, done?: DoneCallback, _forceBraces?: boolean): Piece[] | undefined {
-    const _ShExWriter = this;
+    const _ShExCWriter = this;
     try {
       const pieces: Piece[] = []; // guessing push/join is faster than concat
       this._expect(shape, "type", "Shape");
@@ -229,14 +229,14 @@ class ShExWriter {
       if (shape.closed) pieces.push("CLOSED ");
 
       [{keyword: "extends", marker: "EXTENDS "}].forEach(pair => {
-         // pieces = pieces.concat(_ShExWriter._writeShapeExpr(expr.valueExpr, done, true, 0));
+         // pieces = pieces.concat(_ShExCWriter._writeShapeExpr(expr.valueExpr, done, true, 0));
          const exprs = (shape as any)[pair.keyword] as ShExJ.shapeExprOrRef[] | undefined;
          if (exprs && exprs.length > 0) {
            exprs.forEach(function (i, ord) {
              if (ord)
                pieces.push(" ")
              pieces.push(pair.marker);
-             [].push.apply(pieces, _ShExWriter._writeShapeExpr(i, done, true, 0) as never[]);
+             [].push.apply(pieces, _ShExCWriter._writeShapeExpr(i, done, true, 0) as never[]);
            });
            pieces.push(" ");
          }
@@ -245,7 +245,7 @@ class ShExWriter {
       if (shape.extra && shape.extra.length > 0) {
         pieces.push("EXTRA ");
         shape.extra.forEach(function (i) {
-          pieces.push(_ShExWriter._encodeShapeName(i, false)+" ");
+          pieces.push(_ShExCWriter._encodeShapeName(i, false)+" ");
         });
         pieces.push(" ");
       }
@@ -256,9 +256,9 @@ class ShExWriter {
           return;
 
         semActs.forEach(function (act) {
-          _ShExWriter._expect(act, "type", "SemAct");
+          _ShExCWriter._expect(act, "type", "SemAct");
           pieces.push(" %",
-                      _ShExWriter._encodePredicate(act.name),
+                      _ShExCWriter._encodePredicate(act.name),
                       ("code" in act ? "{"+escapeCode(act.code!)+"%"+"}" : "%"));
         });
       }
@@ -277,9 +277,9 @@ class ShExWriter {
           if (semActs) {
 
             semActs.forEach(function (act) {
-              _ShExWriter._expect(act, "type", "SemAct");
+              _ShExCWriter._expect(act, "type", "SemAct");
               pieces.push("\n"+indent+"   %");
-              pieces.push(_ShExWriter._encodeValue(act.name));
+              pieces.push(_ShExCWriter._encodeValue(act.name));
               if ("code" in act)
                 pieces.push("{"+escapeCode(act.code!)+"%"+"}");
               else
@@ -305,12 +305,12 @@ class ShExWriter {
 
         if (typeof expr === "string") {
           pieces.push("&");
-          pieces.push(_ShExWriter._encodeShapeName(expr, false));
+          pieces.push(_ShExCWriter._encodeShapeName(expr, false));
         } else {
 
         if ("id" in expr && expr.id !== undefined) {
           pieces.push("$");
-          pieces.push(_ShExWriter._encodeIriOrBlankNode(expr.id, true));
+          pieces.push(_ShExCWriter._encodeIriOrBlankNode(expr.id, true));
         }
 
         if (expr.type === "TripleConstraint") {
@@ -319,32 +319,32 @@ class ShExWriter {
           if ((expr as any).negated)
             pieces.push("!");
           pieces.push(indent,
-                      _ShExWriter._encodePredicate(expr.predicate),
+                      _ShExCWriter._encodePredicate(expr.predicate),
                       " ");
 
           if ("valueExpr" in expr)
-            [].push.apply(pieces, _ShExWriter._writeShapeExpr(expr.valueExpr!, done, true, 0) as never[]);
+            [].push.apply(pieces, _ShExCWriter._writeShapeExpr(expr.valueExpr!, done, true, 0) as never[]);
           else
             pieces.push(". ");
 
           _writeCardinality(expr.min, expr.max);
-          _ShExWriter._annotations(pieces, expr.annotations, indent);
+          _ShExCWriter._annotations(pieces, expr.annotations, indent);
           _writeExpressionActions(expr.semActs);
         }
 
         else if (expr.type === "OneOf") {
           const needsParens = "id" in expr || "min" in expr || "max" in expr || "annotations" in expr || "semActs" in expr;
-          _exprGroup(expr.expressions, "\n"+indent+"| ", 1, needsParens || _ShExWriter.forceParens);
+          _exprGroup(expr.expressions, "\n"+indent+"| ", 1, needsParens || _ShExCWriter.forceParens);
           _writeCardinality(expr.min, expr.max); // t: open1dotclosecardOpt
-          _ShExWriter._annotations(pieces, expr.annotations, indent);
+          _ShExCWriter._annotations(pieces, expr.annotations, indent);
           _writeExpressionActions(expr.semActs);
         }
 
         else if (expr.type === "EachOf") {
           const needsParens = "id" in expr || "min" in expr || "max" in expr || "annotations" in expr || "semActs" in expr;
-          _exprGroup(expr.expressions, ";\n"+indent, 2, needsParens || _ShExWriter.forceParens);
+          _exprGroup(expr.expressions, ";\n"+indent, 2, needsParens || _ShExCWriter.forceParens);
           _writeCardinality(expr.min, expr.max); // t: open1dotclosecardOpt
-          _ShExWriter._annotations(pieces, expr.annotations, indent);
+          _ShExCWriter._annotations(pieces, expr.annotations, indent);
           _writeExpressionActions(expr.semActs);
         }
 
@@ -356,7 +356,7 @@ class ShExWriter {
         _writeExpression(shape.expression, "  ", 0);
       pieces.push("\n}");
       _writeShapeActions(shape.semActs);
-      _ShExWriter._annotations(pieces, shape.annotations, "  ");
+      _ShExCWriter._annotations(pieces, shape.annotations, "  ");
 
       return pieces;
     }
@@ -365,21 +365,21 @@ class ShExWriter {
 
   // ### `_writeNodeConstraint` writes the node constraint to the output stream
   _writeNodeConstraint (v: ShExJ.NodeConstraint, done?: DoneCallback): Piece[] | undefined {
-    const _ShExWriter = this;
+    const _ShExCWriter = this;
     try {
-      _ShExWriter._expect(v, "type", "NodeConstraint");
+      _ShExCWriter._expect(v, "type", "NodeConstraint");
 
       const pieces: Piece[] = [];
       if (v.nodeKind! in nodeKinds)      pieces.push(nodeKinds[v.nodeKind!], " ");
-      else if (v.nodeKind !== undefined) _ShExWriter._error("unexpected nodeKind: " + v.nodeKind); // !!!!
+      else if (v.nodeKind !== undefined) _ShExCWriter._error("unexpected nodeKind: " + v.nodeKind); // !!!!
 
       this._fillNodeConstraint(pieces, v, done);
       this._annotations(pieces, v.annotations, "  ");
       if (v.semActs)
         v.semActs.forEach(function (act) {
-          _ShExWriter._expect(act, "type", "SemAct");
+          _ShExCWriter._expect(act, "type", "SemAct");
           pieces.push(" %",
-                      _ShExWriter._encodePredicate(act.name),
+                      _ShExCWriter._encodePredicate(act.name),
                       ("code" in act ? "{"+escapeCode(act.code!)+"%"+"}" : "%"));
         });
       return pieces;
@@ -389,23 +389,23 @@ class ShExWriter {
   }
 
   _annotations (pieces: Piece[], annotations: ShExJ.Annotation[] | undefined, indent: string) {
-    const _ShExWriter = this;
+    const _ShExCWriter = this;
     if (annotations) {
       annotations.forEach(function (a) {
-        _ShExWriter._expect(a, "type", "Annotation");
+        _ShExCWriter._expect(a, "type", "Annotation");
         pieces.push("//\n"+indent+"   ");
-        pieces.push(_ShExWriter._encodeValue(a.predicate));
+        pieces.push(_ShExCWriter._encodeValue(a.predicate));
         pieces.push(" ");
-        pieces.push(_ShExWriter._encodeValue(a.object as any));
+        pieces.push(_ShExCWriter._encodeValue(a.object as any));
       });
     }
   }
 
   _fillNodeConstraint (pieces: Piece[], v: ShExJ.NodeConstraint, _done?: DoneCallback): Piece[] {
-    const _ShExWriter = this;
-    if (v.datatype  && v.values  ) _ShExWriter._error("found both datatype and values in "   +JSON.stringify(v));
+    const _ShExCWriter = this;
+    if (v.datatype  && v.values  ) _ShExCWriter._error("found both datatype and values in "   +JSON.stringify(v));
     if (v.datatype) {
-      pieces.push(_ShExWriter._encodeShapeName(v.datatype));
+      pieces.push(_ShExCWriter._encodeShapeName(v.datatype));
     }
 
     if (v.values) {
@@ -418,14 +418,14 @@ class ShExWriter {
         if (!isTerm(t)) {
 //          expect(t, "type", "IriStemRange");
               if (!("type" in t))
-                _ShExWriter._error("expected "+JSON.stringify(t)+" to have a 'type' attribute.");
+                _ShExCWriter._error("expected "+JSON.stringify(t)+" to have a 'type' attribute.");
           const stemRangeTypes = ["Language", "IriStem", "LiteralStem", "LanguageStem", "IriStemRange", "LiteralStemRange", "LanguageStemRange"];
               if (stemRangeTypes.indexOf(t.type) === -1)
-                _ShExWriter._error("expected type attribute '"+t.type+"' to be in '"+stemRangeTypes+"'.");
+                _ShExCWriter._error("expected type attribute '"+t.type+"' to be in '"+stemRangeTypes+"'.");
           if (t.type === "Language") {
             pieces.push("@" + t.languageTag);
           } else if (!isTerm(t.stem)) {
-            _ShExWriter._expect(t.stem, "type", "Wildcard");
+            _ShExCWriter._expect(t.stem, "type", "Wildcard");
             pieces.push(".");
           } else {
             pieces.push(langOrLiteral(t, t.stem) + "~");
@@ -436,10 +436,10 @@ class ShExWriter {
               if (!isTerm(c)) {
 //                expect(c, "type", "IriStem");
                     if (!("type" in c))
-                      _ShExWriter._error("expected "+JSON.stringify(c)+" to have a 'type' attribute.");
+                      _ShExCWriter._error("expected "+JSON.stringify(c)+" to have a 'type' attribute.");
                     const stemTypes = ["IriStem", "LiteralStem", "LanguageStem"];
                     if (stemTypes.indexOf(c.type) === -1)
-                      _ShExWriter._error("expected type attribute '"+c.type+"' to be in '"+stemTypes+"'.");
+                      _ShExCWriter._error("expected type attribute '"+c.type+"' to be in '"+stemTypes+"'.");
                 pieces.push(langOrLiteral(t, c.stem) + "~");
               } else {
                 pieces.push(langOrLiteral(t, c));
@@ -447,13 +447,13 @@ class ShExWriter {
             });
           }
         } else {
-          pieces.push(_ShExWriter._encodeValue(t));
+          pieces.push(_ShExCWriter._encodeValue(t));
         }
 
         function langOrLiteral (t: any, c: string): string {
           return ["LanguageStem", "LanguageStemRange"].indexOf(t.type) !== -1 ? "@" + c :
             ["LiteralStem", "LiteralStemRange"].indexOf(t.type) !== -1 ? '"' + c.replace(ESCAPE_g, characterReplacer) + '"' :
-            _ShExWriter._encodeValue(c)
+            _ShExCWriter._encodeValue(c)
         }
       });
 
@@ -708,7 +708,7 @@ function _throwError (func: Function | string, str?: string): never {
 }
 
 // Expect property p with value v in object o
-function expect (this: ShExWriter, o: any, p: string, v?: any) {
+function expect (this: ShExCWriter, o: any, p: string, v?: any) {
   if (!(p in o))
     this._error(expect, "expected "+o+" to have a ."+p);
   if (arguments.length > 2 && o[p] !== v)
@@ -718,7 +718,7 @@ function expect (this: ShExWriter, o: any, p: string, v?: any) {
 // The empty function
 function noop () {}
 
-/* The runtime export is the ShExWriter class itself (module.exports = ShExWriter)
+/* The runtime export is the ShExCWriter class itself (module.exports = ShExCWriter)
  * for compatibility with `new (require('@shexjs/writer'))(...)` callers.
  */
-export = ShExWriter;
+export = ShExCWriter;

--- a/packages/shex-writer/test/WriterApi-test.js
+++ b/packages/shex-writer/test/WriterApi-test.js
@@ -10,7 +10,7 @@
 "use strict";
 
 const {expect} = require("chai");
-const ShExWriter = require("@shexjs/writer");
+const ShExCWriter = require("@shexjs/writer");
 
 const S1 = "http://a.example/S1", p1 = "http://a.example/p1";
 const decl = (id, shapeExpr) => ({type: "Schema", shapes: [{type: "ShapeDecl", id, shapeExpr}]});
@@ -34,7 +34,7 @@ function collector () {
 function write (schema, options) {
   let text = null, error = null;
   try {
-    new ShExWriter(Object.assign({simplifyParentheses: true}, options))
+    new ShExCWriter(Object.assign({simplifyParentheses: true}, options))
       .writeSchema(schema, (e, t) => { if (e) error = e; else text = t; });
   } catch (e) { error = e; }
   return {text, error};
@@ -46,7 +46,7 @@ describe("writer API", function () {
 
     it("should write to a stream it was given", function () {
       const out = collector();
-      new ShExWriter(out, {simplifyParentheses: true}).writeSchema(ONE_DOT);
+      new ShExCWriter(out, {simplifyParentheses: true}).writeSchema(ONE_DOT);
       expect(out.text()).to.include("<" + S1 + ">");
       expect(out.text()).to.include("<" + p1 + ">");
       expect(out.ended, "and close it, by default").to.equal(true);
@@ -56,7 +56,7 @@ describe("writer API", function () {
      * open. */
     it("should leave the stream open with end: false", function () {
       const out = collector();
-      const writer = new ShExWriter(out, {simplifyParentheses: true, end: false});
+      const writer = new ShExCWriter(out, {simplifyParentheses: true, end: false});
       writer.writeSchema(ONE_DOT);
       expect(out.text()).to.include("<" + S1 + ">");
       expect(out.ended).to.equal(false);
@@ -65,13 +65,13 @@ describe("writer API", function () {
     it("should still report done when it doesn't close the stream", function () {
       const out = collector();
       let called = 0;
-      new ShExWriter(out, {end: false}).end(() => ++called);
+      new ShExCWriter(out, {end: false}).end(() => ++called);
       expect(called, "exactly once").to.equal(1);
       expect(out.ended).to.equal(false);
     });
 
     it("should refuse to write after end()", function () {
-      const writer = new ShExWriter({simplifyParentheses: true});
+      const writer = new ShExCWriter({simplifyParentheses: true});
       writer.end();
       expect(() => writer.addShape(shape(tc()), S1))
         .to.throw(/Cannot write because the writer has been closed/);
@@ -84,7 +84,7 @@ describe("writer API", function () {
      * schema uses the writer -- there is no ShExJ document to hand it. */
     it("should take prefixes and shapes one at a time", function () {
       const out = collector();
-      const writer = new ShExWriter(out, {simplifyParentheses: true});
+      const writer = new ShExCWriter(out, {simplifyParentheses: true});
       writer.addPrefix("ex", "http://a.example/");
       writer.addShape(shape(tc()), S1);
       writer.end();
@@ -95,7 +95,7 @@ describe("writer API", function () {
 
     it("should take a list of shapes", function () {
       const out = collector();
-      const writer = new ShExWriter(out, {simplifyParentheses: true});
+      const writer = new ShExCWriter(out, {simplifyParentheses: true});
       writer.addShapes([
         {shape: shape(tc()), name: S1},
         {shape: shape(tc({predicate: "http://a.example/p2"})), name: "http://a.example/S2"},
@@ -133,7 +133,7 @@ describe("writer API", function () {
   /* One shape expression, returned rather than written: how an error message
    * quotes the constraint a node didn't satisfy. */
   it("should write a shape expression on its own", function () {
-    const writer = new ShExWriter({simplifyParentheses: true, prefixes: {ex: "http://a.example/"}});
+    const writer = new ShExCWriter({simplifyParentheses: true, prefixes: {ex: "http://a.example/"}});
     expect(writer.writeShapeExpr({type: "NodeConstraint", datatype: "http://a.example/dt", mininclusive: 3}))
       .to.equal("ex:dt mininclusive 3");
     expect(writer.writeShapeExpr(shape(tc()), true)).to.include("ex:p1");
@@ -201,7 +201,7 @@ describe("writer API", function () {
     /* the error thrower is replaceable, e.g. to collect rather than throw */
     it("should use the error function it was given", function () {
       const said = [];
-      const writer = new ShExWriter({
+      const writer = new ShExCWriter({
         simplifyParentheses: true,
         error: (func, str) => { said.push(typeof func === "function" ? str : func); },
       });


### PR DESCRIPTION
Finishing-pass item (I3/G5). The writer emits **ShExC**, so the name now says so.

A clarity rename with **no API change**: `@shexjs/writer`'s runtime export is the class itself (`export = ShExCWriter`), so consumers name it locally — the class, its options interface (`ShExCWriterOptions`), the internal `_ShExCWriter` alias, and the call sites in the CLI, `shex-util/error-messages` and the two writer tests all move together (90 occurrences across 5 files).

Full gated suite (cli + browser + server) passes (6149).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBCrywES6wuj3RHqExHA7S