### PR TITLE
types: narrow RdfJs → @rdfjs/types DataFactory (globals.d.ts)

### DIFF
--- a/packages/shex-webapp/src/app/globals.d.ts
+++ b/packages/shex-webapp/src/app/globals.d.ts
@@ -1,14 +1,21 @@
 /**
- * What the page gives the app's scripts and TypeScript cannot see: the
- * bundles' globals, jQuery, and the two things the page's head script
- * declares.  Everything here is `any` for now; narrowing them is the
- * work plan.md's B1 describes.
-
+ * What the page gives the app's scripts and TypeScript cannot otherwise see:
+ * the bundles' globals, jQuery, and the two things the page's head script
+ * declares.
+ *
+ * `RdfJs` is typed against `@rdfjs/types` -- the data factory the app builds
+ * terms with, and the one global here with installed type declarations.  The
+ * rest stay `any` on purpose: jQuery, CodeMirror, marked, N3js and IRI are
+ * CDN-loaded third parties with no `@types/*` installed, and `ShExWebApp` is
+ * this repo's own bundle, which carries no `types` entry yet.  Narrowing those
+ * is the larger B1 follow-on: it wants `@types/*` pulled in (or a `types`
+ * entry published on `@shexjs/webapp`) and the resulting cascade of fixes
+ * absorbed under `strict` -- not a one-line change like `RdfJs` was.
  */
 declare const $: any;
 declare const jQuery: any;
 declare const ShExWebApp: any;
-declare const RdfJs: any;
+declare const RdfJs: import("@rdfjs/types").DataFactory;
 declare const N3js: any;
 declare const CodeMirror: any;
 declare const IRI: any;


### PR DESCRIPTION
Finishing-pass item (B1 next-narrowing) — the bounded, clean piece of it.

The probe showed globals.d.ts is really the **heavy** B1 follow-on: only `@rdfjs/types` ships installed type declarations. So this PR narrows the one clean win — `RdfJs` → `DataFactory` — which type-checks all 26 uses with **0 errors** and emits identically (a `.d.ts` change, no runtime effect).

The header comment now records why the rest stay `any`: jQuery, CodeMirror, marked, N3js, IRI are CDN-loaded with no `@types/*`, and `ShExWebApp` (99 uses) is our own bundle with no `types` entry. Narrowing those needs `@types/*` added (or a `types` entry on `@shexjs/webapp`) plus a `strict` cascade absorbed — recommend keeping it deferred with the other heavy items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBCrywES6wuj3RHqExHA7S