### PR TITLE
docs: pre-alpha.31 survey — fix doc/code skew + bugs it surfaced

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The result is a JSON structure which tells you exactly how the data matched the 
 
 ```json
 {
-  "type": "test",
+  "type": "ShapeTest",
   "node": "http://shex.io/examples/Issue1",
   "shape": "http://shex.io/examples/IssueShape",
   "solution": {
@@ -90,7 +90,7 @@ const node = "http://shex.io/examples/Issue1#Issue1"; // node in that data
 
 const N3 = require("n3");
 const ShExLoader = require("@shexjs/loader")({        // initialize with:
-  fetch: require('node-fetch'),                       //   fetch implementation
+  fetch: globalThis.fetch,                            //   fetch implementation (Node >=18)
   rdfjs: N3,                                          //   RdfJs Turtle parser
 });
 const { ctor: RdfJsDb } = require('@shexjs/neighborhood-rdfjs');
@@ -121,26 +121,26 @@ ShEx can be represented in the compact syntax
 ```
 PREFIX ex: <http://ex.example/#>
 <IssueShape> {                       # An <IssueShape> has:
-    ex:state (ex:unassigned            # state which is
-              ex:assigned),            #   unassigned or assigned.
+    ex:state [ex:unassigned            # state which is
+              ex:assigned],            #   unassigned or assigned.
     ex:reportedBy @<UserShape>        # reported by a <UserShape>.
 }
 ```
 or in JSON:
 ```json
-{ "type": "schema", "start": "http://shex.io/examples/IssueShape",
-  "shapes": {
-    "http://shex.io/examples/IssueShape": { "type": "shape",
-      "expression": { "type": "eachOf",
-        "expressions": [
-          { "type": "tripleConstraint", "predicate": "http://ex.example/#state",
-            "valueExpr": { "type": "valueClass", "values": [
-                "http://ex.example/#unassigned", "http://ex.example/#assigned"
-          ] } },
-          { "type": "tripleConstraint", "predicate": "http://ex.example/#reportedBy",
-            "valueExpr": { "type": "valueClass", "reference": "http://shex.io/examples/UserShape" }
-          }
-] } } } }
+{ "type": "Schema", "start": "http://shex.io/examples/IssueShape",
+  "shapes": [
+    { "id": "http://shex.io/examples/IssueShape", "type": "ShapeDecl",
+      "shapeExpr": { "type": "Shape",
+        "expression": { "type": "EachOf",
+          "expressions": [
+            { "type": "TripleConstraint", "predicate": "http://ex.example/#state",
+              "valueExpr": { "type": "NodeConstraint", "values": [
+                  "http://ex.example/#unassigned", "http://ex.example/#assigned"
+              ] } },
+            { "type": "TripleConstraint", "predicate": "http://ex.example/#reportedBy",
+              "valueExpr": "http://shex.io/examples/UserShape" }
+] } } } ] }
 ```
 
 You can convert between them with shex-to-json:
@@ -157,7 +157,7 @@ As with validation, the ShExLoader wraps the fetching and parsing:
 const shexc = "http://shex.io/examples/Issue.shex";
 
 const ShEx = require("shex");
-const ShExLoader = ShEx.Loader({fetch: require("node-fetch"), rdfjs: require("n3")});
+const ShExLoader = ShEx.Loader({fetch: globalThis.fetch, rdfjs: require("n3")});
 ShExLoader.load({shexc: [shexc]}, null).then(function (loaded) {
     console.log(JSON.stringify(loaded.schema, null, "  "));
 });
@@ -194,7 +194,7 @@ The syntax is:
 ```sh
 shexmap-materialize `-t <target schema>`|-h [-j `<JSON Vars File>`] [-r `<RDF root IRI>`]
 ```
-It reads the output of `shex-validate --extension` from STDIN and maps it to the specified target schema (`--extension` takes a path to the extension module).
+It reads the output of `shex-validate --extension` from STDIN and maps it to the specified target schema (`--extension` takes a package name or file glob for the extension module).
 
 If supplied, a JSON vars file will be referenced to fill in constant values not specified from the source.
 This is useful in assigning default fields to the target when there is no equivalent value in the source schema
@@ -218,7 +218,7 @@ npx shexmap-materialize -h
 ```
 ```sh
 npx shex-validate -x source_schema.shex -d data.ttl -s ProblemShape -n prob1 \
-    --extension node_modules/@shexjs/extension-map \
+    --extension @shexjs/extension-map \
   | npx shexmap-materialize -t target_schema.shex -j vars.json
 ```
 ```sh
@@ -261,6 +261,17 @@ This repo uses [npm workspaces](https://docs.npmjs.com/cli/using-npm/workspaces)
 - [`@shexjs/extension-wasi-test`](packages/extension-wasi-test#readme) -- the Test extension reimplemented in hand-written WebAssembly, printing via WASI fd_write
 - [`@shexjs/extension-map`](packages/extension-map#readme) -- an extension for transforming data from one schema to another ([more](http://shex.io/extensions/Map/))
 - [`@shexjs/extension-eval`](packages/extension-eval#readme) -- simple extension which evaluates Javascript semantic action code ([more](http://shex.io/extensions/Eval/))
+- [`@shexjs/extension-reduce`](packages/extension-reduce#readme) -- the Reduce extension (the inverse of Map)
+- [`@shexjs/extension-reduce-js`](packages/extension-reduce-js#readme) -- the Reduce extension's JavaScript semantic-action handler
+- [`@shexjs/extension-wasi`](packages/extension-wasi#readme) -- run WAT/Wasm semantic actions via WASI
+- [`@shexjs/eval-validator-api`](packages/eval-validator-api#readme) -- the regex-engine interface the validator drives (with capture/replay debug hooks)
+- [`@shexjs/eval-simple-1err`](packages/eval-simple-1err#readme) is the "fast" engine (stops at the first error); [`@shexjs/eval-threaded-nerr`](packages/eval-threaded-nerr#readme) the "thorough" default (reports every error)
+- [`@shexjs/neighborhood-api`](packages/neighborhood-api#readme) -- the NeighborhoodDb interface the data sources implement
+- [`@shexjs/neighborhood-rdfjs`](packages/neighborhood-rdfjs#readme) -- a NeighborhoodDb over an in-memory RDF/JS store
+- [`@shexjs/neighborhood-sparql`](packages/neighborhood-sparql#readme) -- a NeighborhoodDb over a SPARQL endpoint
+- [`@shexjs/neighborhood-wikibase`](packages/neighborhood-wikibase#readme) -- a NeighborhoodDb over a Wikibase's entity JSON
+- [`@shexjs/semact-overlay`](packages/semact-overlay#readme) -- a visitor overlay that indexes semantic actions
+- [`@shexjs/editor-services`](packages/shex-editor-services#readme) -- editor language services (lint, hover, complete)
 
 ## building
 

--- a/doc/debugger-design.md
+++ b/doc/debugger-design.md
@@ -5,7 +5,7 @@ ShapeExpression or TripleExpression; set **breakpoints in validation and
 materialization schemas** and **on the lexical representation of a graph
 node**.
 
-> **Status**: phases 1–4 are *implemented*.
+> **Status**: phases 1–6 are *implemented*.
 > Materialization: `ThreadedMaterializer.run()` is a step-event generator
 > and `MaterializerDebugger` (both in
 > `packages/extension-map/lib/ThreadedMaterializer.js`) provides
@@ -23,8 +23,9 @@ node**.
 > `ShExValidator`'s options), and `shex-debug` steps into them --
 > `b LINE` prefers the constraint on the line, `bp PRED` breaks on a
 > predicate.
-> What remains — phase 6's live stepping, a unified panel, worker-app
-> debugging and the polish items — is tracked in [plan.md](plan.md) §E.
+> What remained — phase 6's live stepping, a unified panel, worker-app
+> debugging — has since shipped; only the E12 polish item (a steppable
+> eval-threaded-nerr) stays deferred in [plan.md](plan.md) §E.
 > Browser validation debugging shipped as **capture + replay** (see §1):
 > the validate-side 🐞 in shex-simple/shexmap-simple reruns the
 > validation with `capturingRegexModule` recording every
@@ -204,7 +205,7 @@ the recorded matches are on offer.
 
 `shex-debug` (in `@shexjs/cli`): loads schema/data/shape-map like
 `shex-validate`, runs the engine in a `worker_threads` worker, REPL commands
-`c`/`s`/`n`/`o`/`b <line|term>`/`bt`/`info bindings`/`q`.  The materializer
+`s`/`n`/`o`/`c`/`b LINE[:COL]`/`bs SHAPE`/`bp PREDICATE`/`bn NODE`/`info`/`l`/`h`/`q`.  The materializer
 variant needs no worker at all (the generator is synchronous and
 single-threaded) — `shexmap-debug` can ship first.
 

--- a/doc/editor-integration-plan.md
+++ b/doc/editor-integration-plan.md
@@ -38,7 +38,7 @@
 >   (`synthesizeLocations`) and linted in its own language (`lintSchema`).
 >   The data side parses with lezer-turtle, not millan.
 > - 2026-08-29: the schema pane parses with a Lezer ShExC grammar
->   (`packages/lezer-shexc`, a port of the specification's grammar in
+>   (`lezer-shexc`, its own repo/npm package, a port of the specification's grammar in
 >   `ShExJison.jison`'s LALR shape): exact colours by role, folding,
 >   incremental and error-tolerant.  The stream tokenizer is gone.  The
 >   ts-jison `@$` wart is fixed on a branch of ts-jison (plan.md D8).

--- a/doc/error-reporting-comparison.md
+++ b/doc/error-reporting-comparison.md
@@ -132,5 +132,5 @@ validating :x as :S:
 ```
 
 The schema fragments in those sentences are ShExC, written by
-`ShExWriter.writeShapeExpr` in the schema's own prefixes, rather than the
+`ShExCWriter.writeShapeExpr` in the schema's own prefixes, rather than the
 ShExJ they are made of.

--- a/doc/error-reporting.md
+++ b/doc/error-reporting.md
@@ -114,8 +114,9 @@ both callers, so the two can't drift again.
 
 ### F2. ShExC in sentences, not JSON (S) — done
 
-Give `@shexjs/writer` a public fragment entry point (`writeShapeExpr(expr,
-{prefixes})`, wrapping what `_writeShapeExpr` already does) and use it from
+Give `@shexjs/writer` a public fragment entry point (`writeShapeExpr(expr)`,
+wrapping what `_writeShapeExpr` already does; prefixes come from the writer's
+constructor, `new ShExCWriter({prefixes})`) and use it from
 the single renderer, so a message reads `…doesn't satisfy xsd:integer
 mininclusive 3`. Prefixes come from the schema's own, so the sentence uses
 the reader's spelling.

--- a/doc/plan.md
+++ b/doc/plan.md
@@ -68,9 +68,11 @@ scripts' move to TypeScript and the untracked `.map`s are done (B1–B10,
   `noImplicitThis` found three nested functions reading `this` as the
   app -- the drag-and-drop `inject`, the LOG_PROGRESS trace's `sm`, the
   shape-map menu's failure report -- each a TypeError waiting; fixed.
-  Left `any`, honestly: what arrives through the bundles' globals
-  (jQuery, ShExWebApp.*, RdfJs, the editor panes) -- typing
-  `globals.d.ts` against the packages' own types is the next narrowing.
+  Left `any`, honestly: what arrives through the bundles' globals.  `RdfJs`
+  now types against `@rdfjs/types` (#453); the rest stay `any` -- jQuery,
+  CodeMirror, marked, N3js and IRI are CDN-loaded with no `@types/*`, and
+  `ShExWebApp` (the repo's own bundle) has no `types` entry -- narrowing them
+  wants `@types/*` added and a `strict` cascade absorbed, deferred.
   `extension-wasi*` are TypeScript too (same day), and so is the CLI:
   `shex-cli/src/validate.ts` -> `lib/validate.js` behind a two-line
   `bin/validate` (`module: node16`, which keeps the script's native
@@ -287,10 +289,13 @@ overflowing the stack and ShapeNot stays a clean error (F3), and
 `options.requireBindingsInSubshapes` drops the islands a static-only
 optional subshape would emit unasked (F4) -- all 2026-08-29.
 
-- **F1 (L)** PikeVM worklist dedup on (state, callStack, cursor); subsumes
-  the post-accept `exploreSteps` budget that can settle for a suboptimal
-  accept (`lastReport.explorationTruncated`).  The design note sketches it
-  and the lazy-DFA beyond.
+- **F1 (worklist dedup done 2026-09-04; lazy-DFA deferred)** The PikeVM
+  worklist dedups on (stateNo, callStack, cursor, repeats), pruning redundant
+  threads at pop (`ThreadedMaterializer`'s `seen` set, reported as
+  `lastReport.configsPruned`); it subsumes the post-accept `exploreSteps`
+  budget that could settle for a suboptimal accept.  The lazy-DFA the design
+  note sketches beyond it stays deferred -- a further optimization, not a
+  correctness gap.
 
 ## G. Errors and validation
 
@@ -368,7 +373,7 @@ The Makefile is hand-maintained; the generator it grew out of
   for every contributor, and a corpus that is an upstream artifact anyway.
   Not a fixture repository: a submodule's friction buys nothing for files
   nobody hand-edits.
-- **I4 (before publishing; 2026-08-30)** What a `publish-ordered` run
+- **I4 (done -- published 2026-08-31, completed 2026-09-05)** What a `publish-ordered` run
   needs first.  Never published: `lezer-shexc`, `@shexjs/editor-services`,
   `@shexjs/neighborhood-wikibase`, `@shexjs/extension-wasi`,
   `@shexjs/extension-wasi-test` (the order handles them; `extension-wasi`
@@ -385,7 +390,11 @@ The Makefile is hand-maintained; the generator it grew out of
   prerelease with no dist-tag, and the alphas have always been `latest`;
   the tool insists on one up front).  A dry run on 2026-08-30 (`--dry-run
   --tag latest`, before the suite bump) published nine and skipped twenty
-  whose versions the registry already had.
+  whose versions the registry already had.  Published for real 2026-08-31
+  (tag `v1.0.0-alpha.30`, fff21dfe); a partial run left seven behind
+  (editor-services, extension-reduce{,-js}, extension-wasi{,-test},
+  neighborhood-wikibase, semact-overlay), published from the tag 2026-09-05
+  to complete 29/29.
 - **I5 (done 2026-08-30) Two version lines.**  Packages with an audience
   outside shex.js -- `shape-map`, `lezer-shexc`, `lezer-turtle` (its own
   repository, on npm as of today) -- are on version lines of their own;
@@ -399,9 +408,8 @@ The Makefile is hand-maintained; the generator it grew out of
   leaves those versions and the ranges pointing at them alone, and
   `publish-ordered.js` skips a package whose version the registry already
   has.  Rule: suite -> tier with `^`; tier -> tier; tier never -> suite.
-  Their versions are theirs to move: `shape-map` is `1.0.0-alpha.26` on
-  the registry and has changed (no util) -- `1.0.0` when it next publishes
-  is the suggestion.
+  Their versions are theirs to move: `shape-map` published `1.0.0` with
+  alpha.30 (no util); `1.1.0` is staged in-tree for the next release.
 - **I6 (staged 2026-08-30) `lezer-shexc` is its own repository**,
   `shexjs/lezer-shexc` (the org, not a personal account: the rdfjs model,
   where the same maintainers hold the implementation and its grammars --
@@ -426,23 +434,21 @@ The Makefile is hand-maintained; the generator it grew out of
   lockstep line and co-owns the validator's `semActIndex` contract with
   `extension-reduce`; a package leaves when its dependency on shex.js is
   on a released API rather than a co-developed one.
-- **I3 (on request; investigated 2026-09-04)** Majors not yet taken.  An
-  isolated-worktree probe (each bumped, `npm ci`, the full gated suite) found
-  **eight safe together in one PR** -- chai 6, eslint 10, glob 13, js-yaml 5,
-  koa 3, n3 2, jquery 4 (jsonld was **already** at `^9.0.0`; this line was
-  stale) -- verified green installed simultaneously.  Two need their own
-  change: **node-fetch 3** is ESM-only, so `require('node-fetch')` must
-  become `.default` (or Node's global `fetch`) at three product sites +
-  test harnesses; **pre-commit→husky** is a tooling swap (clears the
-  `cross-spawn`-via-pre-commit audit finding).  Two caveats for the batch:
-  eslint 10 raises the dev Node floor to 20.19+/22.13+/24+ (devDep only), and
-  the browser run wants `--max-old-space-size` headroom.  **Unverified on the
-  CI Node-20 lane**: the probe ran on Node 26 (where `require()` of ESM
-  works); chai 6 is ESM-only, so it needs checking on the Node-20 job before
-  merging.  Still this repo's own: renaming `ShExWriter` (it writes ShExC) to
-  `ShExCWriter`.  Remaining `npm audit` findings are in pre-commit's and
-  `@ts-jison`'s transitive chains.
+- **I3 (done 2026-09-05)** The dependency majors, taken.  The eight-safe batch
+  landed in #444 (chai 6, eslint 10, glob 13, js-yaml 5, koa 3, n3 2, jquery 4;
+  jsonld was already `^9`), green on the CI Node-20 lane.  The ESM-only pair
+  went to built-ins rather than the bumps -- **node-fetch dropped for the
+  global `fetch`** and **chalk for an inline TTY underline** (#445; both were
+  ESM-only, breaking `require()` on Node 18-20.18).  `rdf-data-factory` 2
+  (#446) and `webpack-cli` 7 (#447) followed; **`typescript` 7 stays out** --
+  it is the native Go port ("tsgo"), whose main entry no longer exports the
+  classic compiler API `ts-jison`/`ts-loader` need.  The dev-major tail
+  `mocha` 12 + `sinon` 22 is in (#450), **pre-commit → husky** done (#451,
+  clearing the `cross-spawn` audit finding), and the `ShExWriter` →
+  `ShExCWriter` rename done (#452).  Remaining `npm audit` findings are in
+  `@ts-jison`'s transitive chain.
 
 ## Decisions wanted
 
-The independent tier's versions (`shape-map` to `1.0.0`?).
+(none open -- `shape-map` published `1.0.0` with alpha.30; `1.1.0` is staged
+for the next release.)

--- a/packages/eval-simple-1err/eval-simple-1err.d.ts
+++ b/packages/eval-simple-1err/eval-simple-1err.d.ts
@@ -1,7 +1,0 @@
-export const description: string;
-
-export const name: string;
-
-export function compile(schema: any, shape: any, index: any): any;
-
-

--- a/packages/extension-eval/README.md
+++ b/packages/extension-eval/README.md
@@ -6,7 +6,7 @@
 A semantic-action extension that evaluates JavaScript written in a schema's
 semantic actions, registering as `http://shex.io/extensions/Eval/`.  Load
 it into `shex-validate` with `--extension @shexjs/extension-eval`, or into a
-validator you construct with `require("@shexjs/extension-eval").register(validator, ShEx)`.
+validator you construct with `require("@shexjs/extension-eval").register(validator, {ShExTerm})`.
 
 ```sh
 npm install @shexjs/extension-eval

--- a/packages/extension-map/README.md
+++ b/packages/extension-map/README.md
@@ -6,7 +6,7 @@
 ShExMap: a semantic-action extension that binds values as a node validates
 (`%Map:{ :name %}` on a triple constraint captures what the triple's object
 was) and materializes a graph of another schema from those bindings.  The
-extension registers as `http://shex.io/extensions/Map/`.
+extension registers as `http://shex.io/extensions/Map/#`.
 
 ```sh
 npm install @shexjs/extension-map
@@ -24,7 +24,7 @@ npm install @shexjs/extension-map
   `npm run build`, which also compiles the library into `lib/`.
 
 The library (`require("@shexjs/extension-map")`) is a factory taking the
-ShEx modules it works with and answering the extension -- `register(validator, ShEx)`,
+ShEx modules it works with and answering the extension -- `register(validator, {ShExTerm})`,
 the `ThreadedMaterializer` and its debugger; see the repository for the
 ShExMap specification and `examples/` for worked pairs.
 

--- a/packages/extension-test/README.md
+++ b/packages/extension-test/README.md
@@ -16,7 +16,7 @@ npm install @shexjs/extension-test
 shex-validate --extension @shexjs/extension-test -x schema.shex -d data.ttl -n <node> -s <shape>
 ```
 
-`require("@shexjs/extension-test").register(validator, ShEx)` installs it on
+`require("@shexjs/extension-test").register(validator, {ShExTerm})` installs it on
 a validator you construct yourself.
 
 ---

--- a/packages/neighborhood-rdfjs/README.md
+++ b/packages/neighborhood-rdfjs/README.md
@@ -32,9 +32,9 @@ console.log(results[0].status);  // "conformant"
 
 ## ctor(store, queryTracker?)
 
-Wraps the store for the Neighborhood API. The store must answer `getQuads(subject, predicate, object, graph)` with quads of RDF/JS terms — N3.js's `Store` does, as does anything implementing the RDF/JS [Store](https://rdf.js.org/stream-spec/#store-interface) match semantics synchronously.
+Wraps the store for the Neighborhood API. The store must implement the RDF/JS `match(subject, predicate, object, graph)` interface, returning quads of RDF/JS terms synchronously — N3.js's `Store` does, as does anything implementing the RDF/JS [Store](https://rdf.js.org/stream-spec/#store-interface) match semantics synchronously.
 
-A validation is a walk: for each node it reaches, the validator asks this db for the node's *neighborhood* — the arcs out of (and, for inverse constraints, into) the node — which is two `getQuads` calls. The optional `queryTracker` hears about each ask, which is how the WebApp paints what a validation touched.
+A validation is a walk: for each node it reaches, the validator asks this db for the node's *neighborhood* — the arcs out of (and, for inverse constraints, into) the node — which is two `match` calls. The optional `queryTracker` hears about each ask, which is how the WebApp paints what a validation touched.
 
 Because the store is local and complete, every kind of constraint works here — `CLOSED` shapes, inverse arcs, blank-node focus nodes — which is why the [shexTest](https://github.com/shexSpec/shexTest) suite runs over this module, and other neighborhoods ([SPARQL](../neighborhood-sparql#readme), [Wikibase](../neighborhood-wikibase#readme)) measure themselves against it.
 

--- a/packages/neighborhood-sparql/README.md
+++ b/packages/neighborhood-sparql/README.md
@@ -13,7 +13,7 @@ This is called by [`@shexjs/validator`](../shex-validator#readme).
 npm install @shexjs/neighborhood-sparql
 ```
 
-## ctor(endpoint: string, queryTracker: QueryTracker?, options: object?)
+## ctor(endpoint: string, queryTracker: DbQueryTracker?, options: object?)
 Present a SPARQL endpoint through the Neighborhood API. Call `setSchema(schema)`
 before validating: the schema says which predicates a neighborhood needs, which
 is what keeps the queries narrow.
@@ -30,6 +30,8 @@ is what keeps the queries narrow.
   (EXTENDS alone revisits nodes once per extended shape), and the graph does
   not change under a validation
 - `executeQuery`: replace the SPARQL transport, e.g. to log queries
+- `executeQueryAsync`: the async form of `executeQuery` (preferred — the DB awaits it)
+- `expectBnodes`: expect blank nodes in every neighborhood rather than probing depth-0 first (default `false`)
 - `rateLimit`: how fast to ask, and what to do when the service says not that
   fast — see below
 

--- a/packages/neighborhood-sparql/package.json
+++ b/packages/neighborhood-sparql/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0-alpha.30",
   "files": [
     "lib",
-    "src"
+    "src",
+    "sync-fetch.js"
   ],
   "description": "Implementation of @shexjs/neighborhood-api which gets data from a SPARQL endpoint",
   "author": {

--- a/packages/neighborhood-wikibase/README.md
+++ b/packages/neighborhood-wikibase/README.md
@@ -52,7 +52,7 @@ they are answered from the store; asking about one this DB has never seen
 raises `EntityResolutionError` rather than returning a quietly empty
 neighborhood.
 
-## ctor(queryTracker: QueryTracker?, options: object?)
+## ctor(queryTracker: DbQueryTracker?, options: object?)
 
 - `cacheDir`: keep each fetched JSON page on disk, so re-validating costs no
   requests. Pages are cached forever — delete a file (or the directory) to
@@ -72,6 +72,7 @@ that wants the site's current answer again.
   `require("@shexjs/neighborhood-sparql/sync-fetch").installXhrShim()`).
   Wikimedia's servers 403 anonymous clients, so a node transport should send
   a real `User-Agent`.
+- `fetchDocAsync(url)`: the async form of `fetchDoc` (preferred; defaults to `fetch()`).
 - `entityDataUrl(id)`, `siteMatrixUrl`, `conceptBase`, `dataBase`,
   `repositoryName`, `commonsMediaBase`, `commonsDataBase`, `license`: point
   at a different Wikibase instance (defaults are wikidata.org's).

--- a/packages/shex-cli/bin/json-to-shex
+++ b/packages/shex-cli/bin/json-to-shex
@@ -35,7 +35,7 @@ function abort (msg, exitCode) {
   output(require('command-line-usage')([
     {
       header: "json-to-shex",
-      content: "load some number of schema files from web or filesystem and display as ShEx compact syntax (ShExC), for example:\n    shex-to-json https://raw.githubusercontent.com/shexSpec/shexTest/main/parsedSchemas/open2dotOr1dotclose.json" },
+      content: "load some number of schema files from web or filesystem and display as ShEx compact syntax (ShExC), for example:\n    json-to-shex https://raw.githubusercontent.com/shexSpec/shexTest/main/parsedSchemas/open2dotOr1dotclose.json" },
     {
       header: 'Options',
       optionList: CommandLineOptions

--- a/packages/shex-cli/src/validate.ts
+++ b/packages/shex-cli/src/validate.ts
@@ -442,7 +442,7 @@ async function findNodesAndValidate (loaded: any, parms: any, options: any, sche
   };
   function allNodesWithType (type: string) {
     const triples = loaded.data.getQuads(null, RDF_TYPE, type);
-    return triples.length > 0 ? triples.map((t: any) => t.subject) : [ShExUtil.NotSupplied];
+    return triples.length > 0 ? triples.map((t: any) => ShExTerm.rdfJsTerm2Ld(t.subject)) : [ShExUtil.NotSupplied];
   };
   function getQuads (s: any, p: any, o: any) {
     const get = s === ShapeMap.Focus ? "subject" : "object";

--- a/packages/shex-loader/README.md
+++ b/packages/shex-loader/README.md
@@ -159,7 +159,7 @@ A no-op here; [`@shexjs/node`](../shex-node#readme) overrides it to load [semant
 
 ### GET function(url, mediaType)
 
-return promise of {contents, url}
+return promise of {text, url}
 
 Examples
 --------

--- a/packages/shex-loader/src/shex-loader.ts
+++ b/packages/shex-loader/src/shex-loader.ts
@@ -6,7 +6,7 @@
  * loadExtensions function(globs[])
  *   prototype of loadExtensions. does nothing
  * GET function(url, mediaType)
- *   return promise of {contents, url}
+ *   return promise of {text, url}
  */
 
 const ShExUtil = require("@shexjs/util");

--- a/packages/shex-term/README.md
+++ b/packages/shex-term/README.md
@@ -25,7 +25,7 @@ Term.rdfJsTerm2Ld(DataFactory.literal("chat", "fr"));
 
 // … and back
 Term.ld2RdfJsTerm({value: "chat", language: "fr"});
-// Literal { id: '"chat"@fr' }
+// a Literal RDF/JS term for "chat"@fr
 
 // either form → Turtle lexical form
 Term.rdfJsTerm2Turtle(DataFactory.literal("chat", "fr"));   // '"chat"@fr'

--- a/packages/shex-util/README.md
+++ b/packages/shex-util/README.md
@@ -12,7 +12,7 @@ npm install @shexjs/util
 ```
 
 ## Invocation
-Using `Partition(<schema>, [<URL>s])` as an example, an illustrative way to invoke it from the command line uses `@shexjs/parser` and `@shexjs/writer`:
+Using `partition(<schema>, [<URL>s])` as an example, an illustrative way to invoke it from the command line uses `@shexjs/parser` and `@shexjs/writer`:
 ``` sh
 node -e 'const base = "http://a.example/"
   const schema = require("@shexjs/parser")
@@ -61,11 +61,11 @@ Note that `<S2>` in the input schema has no references to `<S1>`:
 ## ShExJtoAS(schema)
 Parse a ShExJ schema and add `._prefixes` and `._index` for efficient processing within shexj.js
 
-## ShExAStoJ(schema)
+## AStoShExJ(schema)
 Remove `._prefixes` and `._index` from internal schema structure and add `schema["@context"] || "http://www.w3.org/ns/shex.jsonld"`
 
-## ShExRVisitor:(knownShapeExprs), ShExRtoShExJ(schema-like-object)
-Internal functions for parsing ShExR
+## ShExRtoShExJ(schema-like-object)
+Internal function for parsing ShExR (the `ShExRVisitor` it uses is not exported)
 
 ## canonicalize(schema, trimIRI)
 Normalize ShExJ by moving all tripleExpression references to their first expression.
@@ -90,12 +90,8 @@ Return which predicates appear in which shapes, what their common type is, and w
 ## getDependencies(schema, ret)
 Find which shapes depend on other shapes by inheritance or inclusion.
 
-## Partition(<schema>, [<URL>s])
+## partition(<schema>, [<URL>s])
 Create subset of a schema with only desired shapes and their dependencies.
-
-## merge(left, right, overwrite, inPlace)
-Merge right schema onto left schema if `inPlace` is true; otherwise return a new merged schema.
-`overwrite`: boolean specifies whether to replace an old shape declaration with a new one of the same name.
 
 ## absolutizeResults(res, base)
 In validation results with some relative URLs in it, re-evaluate all [`shape`, `reference`, `node`, `subject`, `predicate`, `object`] property values against `base`.
@@ -122,12 +118,6 @@ Asynchronously execute a SPARQL query against an endpoint.
 
 ## parseSparqlJsonResults (jsonObject)
 Parse JSON results to internal RDF term representations.
-
-## parseSparqlXmlResults_dom(doc)
-Parse XML results in a DOM to internal RDF term representations.
-
-## parseSparqlXmlResults_jquery(jqObj)
-Parse XML results to internal RDF term representations using JQuery.
 
 ---
 

--- a/packages/shex-validator/README.md
+++ b/packages/shex-validator/README.md
@@ -201,7 +201,7 @@ function myValidator (point, shapeLabel, ctx) {
 Validating a schema with external shapes and no `validateExtern` raises:
 
 ```
-TypeError: this.options.validateExtern is not a function
+Error: validating "http://a.example/n2" as EXTERNAL shapeExpr http://a.example/S2 requires a 'validateExtern' option
 ```
 
 # Testing

--- a/packages/shex-visitor/README.md
+++ b/packages/shex-visitor/README.md
@@ -115,7 +115,7 @@ The ShExJ format is defined in [JSG](http://shex.io/shex-semantics/index.html#sh
 
 ## index(schema)
 
-`ShExIndexVisitor.index(schema)` creates a visitor and overrides `visitExpression` and `visitShapeExpr` to provide an index composed of two maps:
+`ShExIndexVisitor.index(schema)` creates a visitor and overrides `visitTripleExpr` and `visitShapeDecl` to provide an index composed of two maps:
 * **shapeExprs** - map from shape declaration name to definition in `schema`,
 * **tripleExprs** - map from triple expression name to definition in `schema`.
 

--- a/packages/shex-writer/README.md
+++ b/packages/shex-writer/README.md
@@ -108,7 +108,7 @@ BASE <http://a.example/>
 ```
 
 ## option: prefixes - Pre-loaded namespace prefixes
-A second parameter to `construct` is a map for prefixes that are not defined in the schema:
+The constructor's options object takes a `prefixes` map for prefixes not defined in the schema:
 ``` sh
 node -e 'new (require("@shexjs/writer"))({
     base: "http://a.example/",


### PR DESCRIPTION
The last step before alpha.31: a documentation survey against the code (four read-only agents covering the library READMEs + typings, the eval/neighborhood packages, the CLI/web-app/extension docs, and the design notes), cross-referencing the open skew issues. Two commits: the doc fixes (+ `plan.md` refresh) and the **code bugs the survey surfaced**.

## Code bugs fixed (commit 1)
- **`shex-validate --node-type` threw** `Unrecognized attributes … termType` — `allNodesWithType` returned raw RDF/JS terms instead of the ld form; now mapped through `ShExTerm.rdfJsTerm2Ld`. **Closes #68.** Verified end-to-end.
- **`@shexjs/neighborhood-sparql/sync-fetch` was missing from the published tarball** (`files: ["lib","src"]`, but the file is at the package root) — yet `@shexjs/cli` requires it (`validate.ts:304`), so a published CLI would throw `Cannot find module`. Added `sync-fetch.js` to `files`. (A real alpha.30 bug.)
- Removed the dead `eval-simple-1err.d.ts` (types → `src`; it wasn't the resolved typing or published).

## Doc skew fixed (commit 2)
- **Root README**: `require('node-fetch')` → `globalThis.fetch`; `"type":"test"` → `"ShapeTest"`; the conversion example's ShExJ **and** its ShExC value set modernized; the workspace package list completed (10 missing packages); `--extension` wording.
- **shex-util**: dropped the removed `merge` / `parseSparqlXmlResults_{dom,jquery}`; `ShExAStoJ`→`AStoShExJ`, `Partition`→`partition`, unexported `ShExRVisitor`.
- **loader** `{contents,url}`→`{text,url}`; **writer** "second parameter to `construct`" → constructor options; **term** `ld2RdfJsTerm` result; **visitor** index overrides; **validator** EXTERNAL error text.
- **neighborhood-rdfjs** `getQuads`→`match`; **sparql/wikibase** `QueryTracker`→`DbQueryTracker` + the `expectBnodes`/`executeQueryAsync`/`fetchDocAsync` options.
- **extensions**: Map IRI `…/Map/`→`…/Map/#`; `register(validator, ShEx)`→`register(validator, {ShExTerm})` (eval/test/map); `json-to-shex` help program name.
- **design notes**: `ShExWriter`→`ShExCWriter`; `packages/lezer-shexc` → the external `lezer-shexc`; debugger phases 1–4→1–6 and the `shex-debug` command list; `writeShapeExpr` signature.
- **plan.md**: F1 done, alpha.30 published 29/29, I3 majors taken, shape-map decision closed, globals RdfJs narrowed.

Full gated suite (cli + browser + server) passes (6149).

## Issue dispositions
Fixed: **#68**. Verified already-resolved (NObug): **#80** (REST server), **#90** (Wikidata EntitySchema), **#77** (demo URL form), **#25** (permalink append), **#419** (visitor constructor — the README already uses the working form; the `.d.ts` premise is moot since `types`→`src`), **#274**.

## Not fixed here — flagged for a decision (code work / judgment)
- **`shex-partition` crashes on every call** (incl. `--help`): `bin/partition` uses multiple `defaultOption` (command-line-args v6 rejects it) atop old v3/`ShExNode` API. It's advertised in the CLI README + `package.json` bin. Needs a bin rewrite or de-advertising.
- **#81** loader `GET(url, mediaType)` ignores `mediaType` (Accept hardcoded to `text/shex,text/turtle,*/*`) — honor it, or document the fixed Accept.
- **extension-reduce** README calls `@shexjs/extension-reduce-js` a *dependency*, but it's a devDependency — move it or reword.
- Broken unadvertised dev scripts `bin/shex-to-turtle` / `bin/shex-to-shacl` (stale requires; the latter has a syntax error) — delete or fix.
- `shex-validator` `regexModule` typing is `ValidatorRegexEngine` but holds a `ValidatorRegexModule`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBCrywES6wuj3RHqExHA7S
