### PR TITLE
fix: doc-survey follow-ups (partition, loader Accept, regexModule type)

### DIFF
--- a/packages/extension-reduce/README.md
+++ b/packages/extension-reduce/README.md
@@ -208,10 +208,10 @@ compiles `calc.shex` and `expr1.ttl` — the example files, unchanged — with a
 second overlay whose actions are JSON templates and a six-line evaluator for
 them, to the same AST the JavaScript actions build.
 
-(The JavaScript one is a *dependency* of this package rather than a
-devDependency for one reason: `shexreduce-webapp.js`, the browser bundle
-the plugin loads, has to put an evaluator on the page, and that is the one
-it ships.)
+(The JavaScript one is a *devDependency*: the runtime library never `require`s
+it — a host that wants JavaScript actions loads an evaluator itself — but the
+browser bundle `shexreduce-webapp.js` embeds one at build time, and that is the
+evaluator it ships.)
 
 An evaluator is a function, so a second action language is not a fork:
 

--- a/packages/shex-cli/bin/partition
+++ b/packages/shex-cli/bin/partition
@@ -1,70 +1,93 @@
 #!/usr/bin/env node
 
-// time ./lib/partition ~/checkouts/hcls/hcls-fhir-rdf/generic/fhir-shapes.shex MedicationPrescriptionShape
+// Extract the shapes some shapes depend on into a smaller schema:
+//   shex-partition -x fhir-shapes.shex MedicationPrescriptionShape
 
-const ShExUtil = require('@shexjs/util');
-const ShExWriter = require('@shexjs/writer');
-const Jsonld = require("jsonld");
+const ShExUtil = require("@shexjs/util");
 const N3 = require("n3");
-const ShExNode = require("@shexjs/node")({rdfjs: N3, jsonld: Jsonld});
+const ShExNode = require("@shexjs/node")({
+  rdfjs: N3,
+  fetch: globalThis.fetch,
+  jsonld: require("jsonld"),
+});
+const ExitCode = require("../lib/ExitCode");
+const ShExCWriter = require("@shexjs/writer");
 
 // Generate command line interface
-const CLI = require("command-line-args")([
-    { name: "help",  alias: "h", type: Boolean },
-    { name: "shex"    ,  alias: "x", type: String, multiple:  true, defaultValue:   [], defaultOption:  true },
-    { name: "json"    ,  alias: "j", type: String, multiple:  true, defaultValue:   [], defaultOption:  true },
-    { name: "includes",  alias: "d", type: String, multiple:  true, defaultValue:   [], defaultOption:  true }
-]);
-
-const includes = process.argv.slice(3); // which shapes to include
-
-function abort (msg) {
-  console.error(msg);
-  console.error(CLI.getUsage({
-    title: "shex-to-json",
-    description: "load some number of schema files from web or filesystem and display as JSON (ShExJ), for example:\n    shex-to-json http://tracker.example/schemas/Issue.shex",
-    footer: "Project home: [underline]{https://github.com/shexSpec/shex.js}"
-  }));
-  process.exit(1);
+const CommandLineOptions = [
+    { name: "help",    alias: "h", type: Boolean },
+    // shex/json take one value per flag (lazyMultiple) so they don't swallow
+    // the positional shape names, which the greedy defaultOption `include` takes
+    { name: "shex",    alias: "x", type: String, lazyMultiple: true, defaultValue: [] },
+    { name: "json",    alias: "j", type: String, lazyMultiple: true, defaultValue: [] },
+    { name: "include", alias: "i", type: String, multiple: true, defaultValue: [], defaultOption: true },
+];
+let CLI;
+try {
+  CLI = require("command-line-args")(CommandLineOptions);
+} catch (e) {
+  abort(e.message, ExitCode.bad_argument);
+}
+function abort (msg, exitCode) {
+  const output = exitCode === ExitCode.help ? console.log : console.error;
+  output(msg);
+  output(require("command-line-usage")([
+    {
+      header: "shex-partition",
+      content: "extract the part of a schema that the named shapes depend on into a smaller schema, for example:\n    shex-partition -x fhir-shapes.shex MedicationPrescriptionShape" },
+    {
+      header: "Options",
+      optionList: CommandLineOptions
+    },
+    {
+      content: "Project home: " + (process.stdout.isTTY ? "\u001b[4mhttps://github.com/shexSpec/shex.js\u001b[24m" : "https://github.com/shexSpec/shex.js")
+    }
+  ]));
+  process.exit(exitCode);
 }
 
 // Extract user commands
-const cmds = CLI.parse();
+const cmds = CLI;
 if (cmds.help)
-    abort("");
-if (cmds.shex.length > 1 && cmds.includes.length === 0) {
-  cmds.includes = cmds.shex.splice(1); // push all but one into includes
-}
-if (cmds.json.length > 1 && cmds.includes.length === 0) {
-  cmds.includes = cmds.json.splice(1); // push all but one into includes
-}
-if (cmds.includes.length === 0) abort("no includes specified");
-if (cmds.shex.length === 0 && cmds.json.length === 0) abort("no shex specified");
+  abort("", ExitCode.help);
+if (cmds.include.length === 0)
+  abort("no shapes to include specified", ExitCode.bad_argument);
+if (cmds.shex.length === 0 && cmds.json.length === 0)
+  abort("no schema specified", ExitCode.bad_argument);
 const input = cmds.shex.concat(cmds.json).join(", ");
 
-
-ShExNode(cmds.shex, cmds.json, []).then(function (loaded) {
+ShExNode.load({shexc: cmds.shex, json: cmds.json}, null, { index: true }).then(function (loaded) {
   console.warn("calculating dependencies for " + input);
   const deps = ShExUtil.getDependencies(loaded.schema);
-  // console.log('%s', JSON.stringify(deps, null, '  '));
+  // resolve bare shape names against the schema's base, as shex-validate does for -s
+  const base = loaded.schema._base;
+  const includes = cmds.include.map(function (name) {
+    try { return base ? new URL(name, base).href : name; } catch (e) { return name; }
+  });
   console.warn("partitioning " + input);
-  partition = ShExUtil.partition(loaded.schema, cmds.includes, deps,
-				 // avoid throwing Error
-				 function (what, why) {
-				   console.warn("Warning: can't find shape "+
-						(why ?
-						 why + " dependency " + what :
-						 what));
-				 });
-  new ShExWriter().
+  const partition = ShExUtil.partition(loaded.schema, includes, deps,
+    // report rather than throw when an included shape isn't found
+    function (what, why) {
+      console.warn("Warning: can't find shape " +
+                   (why ? why + " dependency " + what : what));
+    });
+  new ShExCWriter(null, { simplifyParentheses: true }).
     writeSchema(partition,
-		function (error, text, prefixes) {
-		  if (error) throw error;
-		  else if (text) console.log(text);
-		});
-}).catch(function (e) {
-  console.error("aborting:", e);
-  // if (e.name === "SyntaxError")
-  //   console.error(input+":"+e.line+":"+e.column+": (offset: "+e.offset+"): error: "+e.message);
-})
-
+      function (error, text, prefixes) {
+        if (error) throw error;
+        else if (text) console.log(text);
+      });
+}, function (e) {
+  let exitCode;
+  if (e instanceof ShExNode.WebError) {
+    exitCode = ExitCode.resource_not_found;
+    console.error("Resource error:", e.message);
+  } else if (e instanceof Error) {
+    exitCode = e.code === "ENOENT" ? ExitCode.file_not_found : ExitCode.unspecified_error;
+    console.error(e.stack);
+  } else {
+    exitCode = ExitCode.unspecified_error;
+    console.error("Aborting:", e);
+  }
+  process.exit(exitCode);
+});

--- a/packages/shex-loader/README.md
+++ b/packages/shex-loader/README.md
@@ -159,7 +159,9 @@ A no-op here; [`@shexjs/node`](../shex-node#readme) overrides it to load [semant
 
 ### GET function(url, mediaType)
 
-return promise of {text, url}
+Fetch `url` and return a promise of `{text, url}`. When `mediaType` is given it
+leads the request's `Accept` header (ahead of the `text/shex,text/turtle,*/*`
+fallback), so a server doing content negotiation can honor it.
 
 Examples
 --------

--- a/packages/shex-loader/src/shex-loader.ts
+++ b/packages/shex-loader/src/shex-loader.ts
@@ -187,14 +187,16 @@ function ShExLoaderCjsModule (config: ConfigI = {}): LoaderI {
       ? myHttpRequest(url, mediaType)  // whatever fetch handles
       : (() => { throw new WebError(`Unrecognized URL protocol ${url}`) })()
 
-    async function myHttpRequest (url: string, _mediaType?: string): Promise<LoadedResourceI> {
+    async function myHttpRequest (url: string, mediaType?: string): Promise<LoadedResourceI> {
       if (typeof config.fetch !== "function")
         throw new WebError(`Unable to fetch ${url} with fetch=${config.fetch}`)
       let resp
       try {
         resp = await config.fetch(url, {
           headers: {
-            'Accept': 'text/shex,text/turtle,*/*'
+            // a caller's mediaType leads the Accept header so a server doing
+            // content negotiation can honor it; the fallbacks keep old behavior
+            'Accept': mediaType ? `${mediaType}, text/shex, text/turtle, */*` : 'text/shex,text/turtle,*/*'
           }
         })
       } catch (e: any) {

--- a/packages/shex-validator/src/shex-validator.ts
+++ b/packages/shex-validator/src/shex-validator.ts
@@ -93,7 +93,7 @@ const VERBOSE = false; // "VERBOSE" in process.env;
 const EvalThreadedNErr = require("@shexjs/eval-threaded-nerr").RegexpModule;
 
 interface ValidatorOptions {
-  regexModule?: ValidatorRegexEngine;
+  regexModule?: ValidatorRegexModule; // a module (e.g. eval-threaded-nerr's RegexpModule); the validator calls .compile() on it
   coverage?: {
     exhaustive: string;
     firstError: string;


### PR DESCRIPTION
The follow-up fixes you asked for from the pre-alpha.31 survey:

1. **`shex-partition` rewritten** — it crashed on *every* call (command-line-args v6 rejects its three `defaultOption`s, atop old v3/`ShExNode()` API). Now: v6 + `command-line-usage`, one `defaultOption` (shape names; `lazyMultiple` `-x`/`-j` so they don't swallow them), `ShExNode.load`, `ShExCWriter`, and bare shape names resolve against the schema's base (like `shex-validate`'s `-s`). Verified `--help` works and it partitions a schema to the named shapes + their deps.
2. **Loader Accept (closes #81)** — `GET(url, mediaType)` now leads the `Accept` header with `mediaType` (ahead of the `text/shex,text/turtle,*/*` fallback), so a caller can content-negotiate; README updated.
3. **`regexModule` type** — was `ValidatorRegexEngine`, but it's a *module* the validator calls `.compile()` on → `ValidatorRegexModule` (matches the private field + usage). There was a right answer.
4. **extension-reduce README** — `@shexjs/extension-reduce-js` is a **devDependency** (runtime lib never requires it; the browser bundle embeds an evaluator at build time), not a runtime dependency; reworded.

The unadvertised, not-ready `bin/shex-to-turtle` / `bin/shex-to-shacl` are left as-is by request.

Full gated suite passes (6149).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBCrywES6wuj3RHqExHA7S