### PR TITLE
fix(term): publish shexv.d.ts so @shexjs/term/shexv resolves (#454)

### DIFF
--- a/packages/shex-term/package.json
+++ b/packages/shex-term/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@shexjs/term",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.29",
   "files": [
     "lib",
-    "src"
+    "src",
+    "shexv.d.ts"
   ],
   "description": "Shape Expressions triple expression evaluator - simple regexp returning 1 error.",
   "author": {


### PR DESCRIPTION
Fixes #454 (a TS2307 for consumers).

`@shexjs/term`'s `files` was `["lib","src"]`, which omits the root-level **`shexv.d.ts`** (the ShExJ result-AST types). But five published packages' TS sources — `@shexjs/validator` and the `eval-*` engines — `import` types from `@shexjs/term/shexv`, and they publish their `src` as their `types`. So a consumer compiling TypeScript against `@shexjs/validator` from npm hit `Cannot find module '@shexjs/term/shexv'`.

- Add `shexv.d.ts` to `files` (verified: `npm pack -w @shexjs/term` now includes it).
- Bump `@shexjs/term` to **1.0.0-alpha.29** (independent tier). Consumers depend on `@shexjs/term@^1.0.0-alpha.28`, which accepts alpha.29, so they pick it up on install — no consumer republish needed.

**Not yet fixed on npm** — it ships when `@shexjs/term@alpha.29` is published (next release). I'll leave #454 open until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBCrywES6wuj3RHqExHA7S