### PR TITLE
fix: captureStackTrace browser guards + @types/shexj deps (triage follow-ups)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16088,7 +16088,8 @@
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
         "@shexjs/eval-validator-api": "^1.0.0-alpha.31",
-        "@shexjs/term": "^1.0.0-alpha.28"
+        "@shexjs/term": "^1.0.0-alpha.28",
+        "@types/shexj": "^2.1.7"
       },
       "engines": {
         "node": ">=18"
@@ -16110,7 +16111,8 @@
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
         "@shexjs/eval-validator-api": "^1.0.0-alpha.31",
-        "@shexjs/term": "^1.0.0-alpha.28"
+        "@shexjs/term": "^1.0.0-alpha.28",
+        "@types/shexj": "^2.1.7"
       },
       "engines": {
         "node": ">=18"
@@ -16130,7 +16132,8 @@
       "version": "1.0.0-alpha.31",
       "license": "MIT",
       "dependencies": {
-        "@shexjs/term": "^1.0.0-alpha.28"
+        "@shexjs/term": "^1.0.0-alpha.28",
+        "@types/shexj": "^2.1.7"
       },
       "devDependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -16712,7 +16715,8 @@
       "version": "1.0.0-alpha.31",
       "license": "MIT",
       "dependencies": {
-        "@shexjs/term": "^1.0.0-alpha.28"
+        "@shexjs/term": "^1.0.0-alpha.28",
+        "@types/shexj": "^2.1.7"
       },
       "devDependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -16739,7 +16743,8 @@
       "dependencies": {
         "@shexjs/eval-validator-api": "^1.0.0-alpha.31",
         "@shexjs/neighborhood-api": "^1.0.0-alpha.31",
-        "@shexjs/term": "^1.0.0-alpha.28"
+        "@shexjs/term": "^1.0.0-alpha.28",
+        "@types/shexj": "^2.1.7"
       },
       "devDependencies": {
         "@rdfjs/types": "^2.0.1"
@@ -16768,6 +16773,7 @@
         "@shexjs/term": "^1.0.0-alpha.28",
         "@shexjs/util": "^1.0.0-alpha.31",
         "@shexjs/visitor": "^1.0.0-alpha.31",
+        "@types/shexj": "^2.1.7",
         "n3": "^2.7.4"
       },
       "devDependencies": {
@@ -16831,6 +16837,7 @@
       "license": "MIT",
       "dependencies": {
         "@shexjs/neighborhood-api": "^1.0.0-alpha.31",
+        "@types/shexj": "^2.1.7",
         "n3": "^2.7.4"
       },
       "devDependencies": {
@@ -17200,7 +17207,8 @@
       "dependencies": {
         "@shexjs/term": "^1.0.0-alpha.28",
         "@ts-jison/lexer": "^0.4.1-alpha.1",
-        "@ts-jison/parser": "^0.4.1-alpha.3"
+        "@ts-jison/parser": "^0.4.1-alpha.3",
+        "@types/shexj": "^2.1.7"
       },
       "devDependencies": {
         "@ts-jison/parser-generator": "^0.4.1-alpha.2"
@@ -17270,7 +17278,7 @@
     },
     "packages/shex-term": {
       "name": "@shexjs/term",
-      "version": "1.0.0-alpha.28",
+      "version": "1.0.0-alpha.29",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
@@ -17365,7 +17373,8 @@
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.1",
-        "@shexjs/term": "^1.0.0-alpha.28"
+        "@shexjs/term": "^1.0.0-alpha.28",
+        "@types/shexj": "^2.1.7"
       },
       "engines": {
         "node": ">=18"
@@ -17486,6 +17495,7 @@
       "version": "1.0.0-alpha.31",
       "license": "MIT",
       "dependencies": {
+        "@types/shexj": "^2.1.7",
         "relativize-url": "^0.1.0"
       },
       "engines": {

--- a/packages/eval-simple-1err/package.json
+++ b/packages/eval-simple-1err/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@rdfjs/types": "^2.0.1",
     "@shexjs/eval-validator-api": "^1.0.0-alpha.31",
-    "@shexjs/term": "^1.0.0-alpha.28"
+    "@shexjs/term": "^1.0.0-alpha.28",
+    "@types/shexj": "^2.1.7"
   },
   "scripts": {
     "test": "cd .. && mocha -C -R dot"

--- a/packages/eval-threaded-nerr/package.json
+++ b/packages/eval-threaded-nerr/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@rdfjs/types": "^2.0.1",
     "@shexjs/eval-validator-api": "^1.0.0-alpha.31",
-    "@shexjs/term": "^1.0.0-alpha.28"
+    "@shexjs/term": "^1.0.0-alpha.28",
+    "@types/shexj": "^2.1.7"
   },
   "scripts": {
     "test": "cd .. && mocha -C -R dot"

--- a/packages/eval-validator-api/package.json
+++ b/packages/eval-validator-api/package.json
@@ -25,7 +25,8 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@shexjs/term": "^1.0.0-alpha.28"
+    "@shexjs/term": "^1.0.0-alpha.28",
+    "@types/shexj": "^2.1.7"
   },
   "scripts": {
     "test": "cd ../.. && mocha packages/eval-validator-api/test/*test.js"

--- a/packages/extension-map/src/ShExMaterializer.ts
+++ b/packages/extension-map/src/ShExMaterializer.ts
@@ -1230,7 +1230,7 @@ function noop () {  }
 function runtimeError (...args: any[]) {
   const errorStr = args.join("");
   const e = new Error("Runtime error: " + errorStr);
-  Error.captureStackTrace(e, runtimeError);
+  if ("captureStackTrace" in Error) Error.captureStackTrace(e, runtimeError);
   throw e;
 }
 

--- a/packages/extension-map/src/shex-extension-map.ts
+++ b/packages/extension-map/src/shex-extension-map.ts
@@ -72,7 +72,7 @@ function register (validator: any, api: any) {
        * @return {bool} false if the extension failed or did not accept the ctx object.
        */
       dispatch: function (code: any, ctx: any, extensionStorage: any) {
-        function fail (msg: any) { const e = Error(msg); Error.captureStackTrace(e, fail); throw e; }
+        function fail (msg: any) { const e = Error(msg); if ("captureStackTrace" in Error) Error.captureStackTrace(e, fail); throw e; }
         function getPrefixedName(bindingName: any) {
            // already have the fully prefixed binding name ready to go
            if (typeof bindingName === "string") return bindingName;

--- a/packages/neighborhood-api/package.json
+++ b/packages/neighborhood-api/package.json
@@ -25,7 +25,8 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@shexjs/term": "^1.0.0-alpha.28"
+    "@shexjs/term": "^1.0.0-alpha.28",
+    "@types/shexj": "^2.1.7"
   },
   "scripts": {
     "test": "cd ../.. && mocha packages/neighborhood-api/test/*test.js -R dot"

--- a/packages/neighborhood-rdfjs/package.json
+++ b/packages/neighborhood-rdfjs/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@shexjs/eval-validator-api": "^1.0.0-alpha.31",
     "@shexjs/neighborhood-api": "^1.0.0-alpha.31",
-    "@shexjs/term": "^1.0.0-alpha.28"
+    "@shexjs/term": "^1.0.0-alpha.28",
+    "@types/shexj": "^2.1.7"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/neighborhood-sparql/package.json
+++ b/packages/neighborhood-sparql/package.json
@@ -31,6 +31,7 @@
     "@shexjs/term": "^1.0.0-alpha.28",
     "@shexjs/util": "^1.0.0-alpha.31",
     "@shexjs/visitor": "^1.0.0-alpha.31",
+    "@types/shexj": "^2.1.7",
     "n3": "^2.7.4"
   },
   "scripts": {

--- a/packages/neighborhood-wikibase/package.json
+++ b/packages/neighborhood-wikibase/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@shexjs/neighborhood-api": "^1.0.0-alpha.31",
+    "@types/shexj": "^2.1.7",
     "n3": "^2.7.4"
   },
   "scripts": {

--- a/packages/shape-map/src/ShapeMapParser.ts
+++ b/packages/shape-map/src/ShapeMapParser.ts
@@ -257,7 +257,7 @@ const prepareParser = function (baseIRI: string | null, schemaMeta: ResourceMeta
       const lineNo = "lexer" in parser.yy ? parser.yy.lexer.yylineno + 1 : 1;
       const pos = "lexer" in parser.yy ? parser.yy.lexer.showPosition() : "";
       const t: Error & {location?: Location} = Error(`${baseIRI}(${lineNo}): ${e.message}\n${pos}`);
-      Error.captureStackTrace(t, runParser);
+      if ("captureStackTrace" in Error) Error.captureStackTrace(t, runParser);
       // where it went wrong, for an editor to mark: the parser's own
       // location of the offending token, else the lexer's
       const loc = (e.hash && e.hash.loc) || ("lexer" in parser.yy && parser.yy.lexer.yylloc) || null;

--- a/packages/shex-parser/package.json
+++ b/packages/shex-parser/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "@shexjs/term": "^1.0.0-alpha.28",
     "@ts-jison/lexer": "^0.4.1-alpha.1",
-    "@ts-jison/parser": "^0.4.1-alpha.3"
+    "@ts-jison/parser": "^0.4.1-alpha.3",
+    "@types/shexj": "^2.1.7"
   },
   "devDependencies": {
     "@ts-jison/parser-generator": "^0.4.1-alpha.2"

--- a/packages/shex-visitor/package.json
+++ b/packages/shex-visitor/package.json
@@ -26,7 +26,8 @@
   },
   "dependencies": {
     "@rdfjs/types": "^2.0.1",
-    "@shexjs/term": "^1.0.0-alpha.28"
+    "@shexjs/term": "^1.0.0-alpha.28",
+    "@types/shexj": "^2.1.7"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/shex-visitor/src/shex-visitor.ts
+++ b/packages/shex-visitor/src/shex-visitor.ts
@@ -382,7 +382,7 @@ export class ShExVisitor {
                         return "\"" + p + "\"";
                       }).join(",") +
                       " in " + context + ": " + JSON.stringify(obj));
-      Error.captureStackTrace(e, captureFrame);
+      if ("captureStackTrace" in Error) Error.captureStackTrace(e, captureFrame);
       throw e;
     }
   }

--- a/packages/shex-writer/package.json
+++ b/packages/shex-writer/package.json
@@ -23,6 +23,7 @@
     "node": ">=18"
   },
   "dependencies": {
+    "@types/shexj": "^2.1.7",
     "relativize-url": "^0.1.0"
   },
   "scripts": {

--- a/packages/shex-writer/src/shex-writer.ts
+++ b/packages/shex-writer/src/shex-writer.ts
@@ -703,7 +703,7 @@ function _throwError (func: Function | string, str?: string): never {
     func = _throwError;
   }
   const e = new Error(str);
-  Error.captureStackTrace(e, func as Function);
+  if ("captureStackTrace" in Error) Error.captureStackTrace(e, func as Function);
   throw e;
 }
 


### PR DESCRIPTION
Two low-risk follow-ups from the issue triage (residuals I noted when closing #150 and #274):

- **Browser safety (#150 residual):** guard the five remaining `Error.captureStackTrace` calls (shex-writer, shex-visitor, shape-map, extension-map ×2) with `if ("captureStackTrace" in Error)`, like the validator already does — those error paths would otherwise throw in non-V8 browsers.
- **Type resolution (#274 residual):** declare `@types/shexj` in the ten packages whose published `src` imports `shexj` but relied on transitive/hoisted resolution — a strict/non-hoisted (pnpm) TS consumer could otherwise hit `TS2307`.

No runtime behavior change; full gated suite green (6149). Ships next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBCrywES6wuj3RHqExHA7S