### PR TITLE
fix(webapp): close Controls menu when About opens (#318)

### DIFF
--- a/packages/shex-webapp/doc/ShExBaseApp.js
+++ b/packages/shex-webapp/doc/ShExBaseApp.js
@@ -349,6 +349,7 @@ class ShExBaseApp {
             close: dismissModal
         });
         $("#about-button").click((evt) => {
+            this.toggleControls(); // close the menu; the dialog replaces it (issue #318)
             $("#about").dialog("open");
         });
         $("#gistHelp").dialog({

--- a/packages/shex-webapp/src/app/ShExBaseApp.ts
+++ b/packages/shex-webapp/src/app/ShExBaseApp.ts
@@ -407,6 +407,7 @@ onDataLoad (): void {
     });
 
     $("#about-button").click((evt: any) => {
+      this.toggleControls(); // close the menu; the dialog replaces it (issue #318)
       $("#about").dialog("open");
     });
 


### PR DESCRIPTION
Closes #318. The About-button handler opened the modal dialog without closing the Controls menu, and `#controls` (z-index 127) sits above the jQuery-UI dialog (~100), so the menu painted over the About page. Now it calls `this.toggleControls()` first, mirroring the gist-help handler right beside it. Verified the app still boots and the menu works (smoke test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBCrywES6wuj3RHqExHA7S