### PR TITLE
fix(eval-threaded-nerr): nested EachOf inherits outer group's solution (#70)

### DIFF
--- a/packages/eval-threaded-nerr/src/eval-threaded-nerr.ts
+++ b/packages/eval-threaded-nerr/src/eval-threaded-nerr.ts
@@ -440,7 +440,12 @@ class EvalThreadedNErrRegexEngine implements ValidatorRegexEngine {
           });
           return nextThreads.concat(sub);
         }, []));
-      }, [th]);
+        // Seed this EachOf's expression list from a fresh copy of `th` (its
+        // matching state, but no inherited `.solution`), so a *nested* EachOf
+        // starts its own solution from [] rather than aliasing the parent
+        // EachOf's expressions into its first sibling (issue #70).  `th` itself
+        // is left intact for the outer EachOf's own accumulation.
+      }, [new RegexpThread(ownPool(th.avail), th.errors, th.matched)]);
     }, semActHandler, this.mayMerge));
   }
 

--- a/packages/eval-threaded-nerr/test/EvalThreadedNErr-test.js
+++ b/packages/eval-threaded-nerr/test/EvalThreadedNErr-test.js
@@ -154,4 +154,20 @@ describe("eval-threaded-nerr", function () {
     expect(result.status).to.equal("nonconformant");
     expect(JSON.stringify(result.appinfo)).to.include("MissingProperty");
   });
+
+  // #70: a nested group must build its own solution, not inherit the outer
+  // group's expressions into its first sibling (which used to alias the outer
+  // EachOf's leading constraint into the nested EachOfSolution).
+  it("does not alias the outer EachOf's solution into a nested group (#70)", function () {
+    const result = validate(
+      "PREFIX : <http://a.example/>\nstart = @<P>\n<P> { :t . ; ( :g . ; :f . ) }",
+      'PREFIX : <http://a.example/>\n:x :t 1 ; :g 2 ; :f 3 .');
+    expect(result.status).to.equal("conformant");
+    const eachOfs = [];
+    (function walk (o) { if (o && typeof o === "object") { if (o.type === "EachOfSolution") eachOfs.push(o); Object.values(o).forEach(walk); } })(result);
+    // the nested (:g ; :f) group is the EachOfSolution whose expressions are all triples
+    const nested = eachOfs.find(e => e.expressions.every(x => x.type === "TripleConstraintSolutions"));
+    expect(nested, "nested group solution").to.exist;
+    expect(nested.expressions.map(x => x.predicate)).to.eql([base + "g", base + "f"]);
+  });
 });


### PR DESCRIPTION
Closes #70. The default threaded engine's `matchEachOf` seeded each group's expression list from the incoming thread's `.solution`; for a **nested** EachOf that thread still carried the parent's `.solution`, so the nested group's first sibling aliased the parent's leading expression (e.g. an `rdf:type` solution) into itself — an extra expression in the nested `EachOfSolution` (with the shared object reference the reporter noted). The validation verdict was always correct; only the proof structure was wrong.

Fix: seed the expression reduce from a **fresh copy** of the thread (matching state, no inherited `.solution`), mirroring `matchOneOf` — so a nested group starts from `[]`, and `th` is left intact for the outer EachOf's accumulation.

Verified: the reporter's nested case now yields `[givenName, familyName]` (not 3); regression test added; **full gated suite green (6149)** — no other proof structure disturbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBCrywES6wuj3RHqExHA7S