### PR TITLE
fix: terminate Kleene */+ over a nullable body (#16)

### DIFF
--- a/packages/eval-simple-1err/src/eval-simple-1err.ts
+++ b/packages/eval-simple-1err/src/eval-simple-1err.ts
@@ -327,6 +327,10 @@ class RegExpThread {
       public stack = [],
       public matched: TriplesMatch[] = [],
       public errors = [],
+      /** for each repeat this thread is inside, the triple count when its
+       * current iteration began -- so an iteration that returns to the Rept
+       * with the count unchanged can be recognised as an empty match (#16). */
+      public reptStarts: Repeats = {},
   ) { }
 }
 
@@ -730,10 +734,24 @@ class EvalSimple1ErrRegexEngine implements ValidatorRegexEngine {
         if (!(stateNo in thread.repeats))
           thread.repeats[stateNo] = 0;
         const repetitions = thread.repeats[stateNo];
+        // Triples consumed so far.  An iteration of a nullable body can come
+        // back to this Rept without having grown that count -- it matched
+        // empty -- and re-entering the body would match empty again forever
+        // (issue #16): the outer `*`/`+` over such a body spun off a thread
+        // with an ever-larger repeat counter each generation and never
+        // drained the worklist.  So the back-edge is barred once an iteration
+        // consumes nothing; the empty match can still pad any minimum, so the
+        // exit is offered even below min.
+        const consumedNow = thread.matched.reduce((n, m) => n + m.triples.length, 0);
+        const iterStart = thread.reptStarts[stateNo];
+        const emptyIteration = iterStart !== undefined && iterStart === consumedNow;
         // add(r < s.min ? outs[0] : r >= s.min && < s.max ? outs[0], outs[1] : outs[1])
-        if (repetitions < s.max!)
-          Array.prototype.push.apply(ret, this.addstate(list, s.outs[0], this.incrmRepeat(thread, stateNo), seen)); // outs[0] to repeat
-        if (repetitions >= s.min && repetitions <= s.max)
+        if (repetitions < s.max! && !emptyIteration) {
+          const entered = this.incrmRepeat(thread, stateNo);   // outs[0] to repeat
+          entered.reptStarts[stateNo] = consumedNow;           // this iteration starts here
+          Array.prototype.push.apply(ret, this.addstate(list, s.outs[0], entered, seen));
+        }
+        if ((repetitions >= s.min || emptyIteration) && repetitions <= s.max)
           Array.prototype.push.apply(ret, this.addstate(list, s.outs[1], this.resetRepeat(thread, stateNo), seen)); // outs[1] when done
         return ret;
       } else {
@@ -746,7 +764,8 @@ class EvalSimple1ErrRegexEngine implements ValidatorRegexEngine {
             ownPool(thread.avail), // a thread spends its own triples: see ownPool
             thread.stack,
             thread.matched,
-            thread.errors
+            thread.errors,
+            thread.reptStarts
         )) - 1];
       }
     }
@@ -757,13 +776,21 @@ class EvalSimple1ErrRegexEngine implements ValidatorRegexEngine {
           r[k] = thread.repeats[k];
         return r;
       }, {});
+      // leaving the repeat forgets where its iteration began, so a later
+      // re-entry (an enclosing repeat) starts its empty-match test afresh.
+      const trimmedStarts = Object.keys(thread.reptStarts).reduce<Repeats>((r, k) => {
+        if (parseInt(k) !== repeatedState)
+          r[k] = thread.reptStarts[k];
+        return r;
+      }, {});
       return new RegExpThread(
           thread.state/*???*/,
           trimmedRepeats,
           ownPool(thread.avail),
           thread.stack,
           thread.matched,
-          []
+          [],
+          trimmedStarts
       );
     }
 
@@ -778,7 +805,8 @@ class EvalSimple1ErrRegexEngine implements ValidatorRegexEngine {
         ownPool(thread.avail),
         thread.stack,
         thread.matched,
-        []
+        [],
+        Object.assign({}, thread.reptStarts) // own copy: the caller stamps this iteration's start
       );
     }
 

--- a/packages/eval-threaded-nerr/src/eval-threaded-nerr.ts
+++ b/packages/eval-threaded-nerr/src/eval-threaded-nerr.ts
@@ -623,11 +623,18 @@ class EvalThreadedNErrRegexEngine implements ValidatorRegexEngine {
       minmax.semActs = groupTE.semActs;
     if (groupTE.annotations !== undefined)
       minmax.annotations = groupTE.annotations;
+    // triples a thread has consumed so far, the yardstick for progress: an
+    // iteration that matches a nullable body empty returns with this count
+    // unchanged.
+    const consumed = (th: RegexpThread): number =>
+        th.matched.reduce((n, m) => n + m.triples.length, 0);
     for (; repeated < max && !errOut; ++repeated) {
-      let inner: RegexpThread[] = [];
+      let inner: RegexpThread[] = [];  // iterations that advanced: consumed >= 1
+      let stalled = false;             // some thread matched the body empty
       let stumbled: RegexpThread[] = [];
       for (let t = 0; t < newThreads.length; ++t) {
         const newt = newThreads[t];
+        const before = consumed(newt);
         const sub = evalGroup(newt);
         if (sub.length > 0 && sub[0].errors.length === 0) { // all subs pass or all fail
           sub.forEach(newThread => {
@@ -641,7 +648,15 @@ class EvalThreadedNErrRegexEngine implements ValidatorRegexEngine {
               solutions: solutions
             }, minmax) as groupSolutions;
           });
-          inner = inner.concat(sub);
+          // Only an iteration that consumed a triple may go round again.  One
+          // that consumed none matched a nullable body empty, and re-running
+          // it would match empty forever (issue #16): a `*`/`+` over a body
+          // that can iterate empty never emptied `inner`, so the loop never
+          // ended.  The empty match is a fixpoint -- the frontier reached
+          // before it already stands as the result, and an empty match pads
+          // to any minimum without consuming more -- so it carries no thread
+          // onward; it only records, in `stalled`, that the body was nullable.
+          sub.forEach(s => { if (consumed(s) > before) inner.push(s); else stalled = true; });
         } else {
           // This thread can't take another iteration.  Another might: the
           // threads here are the ways the last iteration could have gone,
@@ -654,9 +669,11 @@ class EvalThreadedNErrRegexEngine implements ValidatorRegexEngine {
         }
       }
       if (inner.length === 0)
-        // none of them could: short of the minimum that is the failure,
-        // and past it the iterations already made stand
-        return repeated < min ? stumbled : newThreads;
+        // Nothing advanced.  If a nullable body matched empty (stalled), the
+        // repeat is satisfied at this level and the frontier already reached
+        // stands.  Otherwise the body failed outright: short of the minimum
+        // that is the failure, and past it the iterations already made stand.
+        return stalled || repeated >= min ? newThreads : stumbled;
       newThreads = mayMerge ? EvalThreadedNErrRegexEngine.mergeEquivalent(inner) : inner;
     }
     const groupSemActs = semActsOn(semActHandler, groupTE);

--- a/packages/eval-threaded-nerr/test/EvalThreadedNErr-test.js
+++ b/packages/eval-threaded-nerr/test/EvalThreadedNErr-test.js
@@ -170,4 +170,35 @@ describe("eval-threaded-nerr", function () {
     expect(nested, "nested group solution").to.exist;
     expect(nested.expressions.map(x => x.predicate)).to.eql([base + "g", base + "f"]);
   });
+
+  /* #16: a Kleene star (or plus) over a *nullable* body -- here a OneOf whose
+   * every branch (`xsd:integer*`, `xsd:string*`) can match zero triples -- used
+   * to iterate the empty match forever and hang both engines.  The empty
+   * iteration must not repeat: the string branch matches "final" once, the
+   * outer star matches once, every triple is consumed, and validation
+   * terminates conformant.  A regression would hang rather than mis-assert, so
+   * the timeout is the real guard. */
+  it("terminates on a repeated nullable body and conforms, both engines (#16)", function () {
+    this.timeout(5000);
+    const schemaText = [
+      "PREFIX ex: <http://a.example/>",
+      "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>",
+      "ex:ObservationShape { ( ex:status xsd:integer* | ex:status xsd:string* )* }",
+    ].join("\n");
+    const dataText = 'PREFIX ex: <http://a.example/>\nex:Obs1 ex:status "final" .';
+    const node = base + "Obs1", shape = base + "ObservationShape";
+
+    // the default (threaded) engine, via the helper
+    const threaded = validate(schemaText, dataText, node, shape);
+    expect(threaded.status, JSON.stringify(threaded.appinfo)).to.equal("conformant");
+
+    // and the NFA engine, which the same empty loop hung
+    const schema = ShExParser.construct(base, {}, {index: true}).parse(schemaText);
+    const graph = new N3.Store();
+    graph.addQuads(new N3.Parser({baseIRI: base, format: "text/turtle"}).parse(dataText));
+    const simple = new ShExValidator(schema, RdfJsDb(graph),
+                                     {regexModule: require("@shexjs/eval-simple-1err").RegexpModule})
+          .validateShapeMap([{node, shape}])[0];
+    expect(simple.status, JSON.stringify(simple.appinfo)).to.equal("conformant");
+  });
 });


### PR DESCRIPTION
Fixes #16.

A Kleene `*` (or `+`) over a **nullable** body — one that can match zero triples, e.g. a `OneOf` whose every branch is itself starred — used to iterate the empty match forever and hang **both** regex engines.

Repro (hung before, conformant now on both engines):
```
ex:ObservationShape { ( ex:status xsd:integer* | ex:status xsd:string* )* }
```
against `ex:Obs1 ex:status "final" .`

## Fix — same principle in both engines
An iteration that consumes **zero** triples matched the nullable body empty and must not go round again; the empty match still pads any minimum, so the repeat may still *exit*. Non-nullable bodies always consume ≥1 triple per iteration, so they never trigger the guard and their behavior is unchanged.

- **`eval-threaded-nerr`** (`matchRepeat`): a sub-thread continues only if `consumed(s) > before`; an empty match instead sets `stalled`, and when nothing advanced the last real frontier stands (`stalled || repeated >= min ? newThreads : stumbled`).
- **`eval-simple-1err`** (NFA `Rept` branch): a new per-thread `reptStarts` records the triple count at each iteration's start; an `emptyIteration` bars the repeat back-edge but still offers the exit. `reptStarts` is copied in `incrmRepeat` (its only mutation site), so sharing elsewhere is read-only.

## Verification
- Both engines terminate and return **conformant** on the repro.
- Full gated suite (`TEST_cli=TEST_browser=TEST_server=true`): **6151 passing, 0 failing**.
- `npm run compile` clean; sanity cases unchanged on both engines: `( :p . )*`, `( :p .+ ; :q . ){2}`, `:p .*`, and the #70 nested-group case.
- New regression test drives the repro through both engines with a 5s timeout as the real guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBCrywES6wuj3RHqExHA7S
