### PR TITLE
fix: close the recursion loophole (#14)

### DIFF
--- a/packages/shex-validator/src/shex-validator.ts
+++ b/packages/shex-validator/src/shex-validator.ts
@@ -245,6 +245,33 @@ class EmptyTracker implements QueryTracker {
   exit(_term: RdfJsTerm, _shapeLabel: string, _res: shapeExprTest) { --this.depth; }
 }
 
+/** The recursion assumptions a result rests on, as a set of `node`@`shape`
+ * keys.  A `Recursion` node is the validator assuming a pair holds because it
+ * is already on the validation stack -- the greatest-fixed-point step -- so a
+ * result carrying one passed only on that assumption.  These are collected once
+ * when the result is memoized and indexed, so that if an assumed pair later
+ * fails the results resting on it can be dropped by lookup (issue #14).  The
+ * whole proof is walked, so an assumption made only through a nested sub-proof
+ * is included too; the key matches the one a failing pair computes for itself. */
+function recursionAssumptions (res: any, into: Set<string> = new Set<string>()): Set<string> {
+  if (res && typeof res === "object") {
+    if (res.type === "Recursion")
+      into.add(JSON.stringify(res.node) + "@" + res.shape);
+    else if (Array.isArray(res))
+      res.forEach(x => recursionAssumptions(x, into));
+    else
+      // Recurse only into data properties: a lazy accessor (the `repairs`
+      // getter builds its answer on first read, and this walk must not be
+      // that read) never holds a Recursion node anyway.
+      for (const key of Object.keys(res)) {
+        const desc = Object.getOwnPropertyDescriptor(res, key);
+        if (desc && desc.get === undefined)
+          recursionAssumptions(res[key], into);
+      }
+  }
+  return into;
+}
+
 type LabelOrStart = shapeDeclLabel | typeof NeighborhoodStart;
 
 interface SeenIndex {
@@ -562,6 +589,11 @@ export class ShExValidator {
   public readonly known: {
     [id: string]: shapeExprTest;
   }
+  /** For each recursion assumption (a `node`@`shape` a `Recursion` node stood
+   * in for), the `known` keys whose result rests on it -- so that when a pair
+   * fails, the results that assumed it can be evicted by lookup instead of
+   * rescanning the whole cache (issue #14). */
+  private readonly contingentOn: { [assumption: string]: Set<string> } = {};
   public readonly schema: InternalSchema;
   /** SemActDispatcherImpl rather than the interface: this is the one that
    * holds the overlay index, and the validator asks it about that. */
@@ -810,8 +842,27 @@ export class ShExValidator {
     if (!ctx.subGraph) {
       ctx.tracker.exit(focus, ctx.label, ret);
       delete ctx.seen[seenKey];
-      if ("known" in this)
+      if ("known" in this) {
         this.known[seenKey] = ret;
+        // Index the recursion assumptions this result rests on, so a later
+        // failure can evict what depended on it by lookup, not by rescanning.
+        for (const assumed of recursionAssumptions(ret))
+          (this.contingentOn[assumed] || (this.contingentOn[assumed] = new Set<string>())).add(seenKey);
+        // If this pair has itself failed, evict every memoized result that
+        // passed only by assuming it on the recursion stack: the recursion
+        // loophole of issue #14, where such a result was reused after its
+        // assumption had been refuted.  A genuinely-recursive result whose
+        // assumption holds is never evicted, so valid co-recursion still
+        // memoizes as before and its proofs are unchanged.
+        if ("errors" in ret) {
+          const failedKey = JSON.stringify(rdfJsTerm2Ld(focus)) + "@" + ctx.label;
+          const dependents = this.contingentOn[failedKey];
+          if (dependents !== undefined) {
+            dependents.forEach(k => { if (k !== seenKey) delete this.known[k]; });
+            delete this.contingentOn[failedKey];
+          }
+        }
+      }
     }
     return ret;
   }

--- a/packages/shex-validator/test/ValidatorEdges-test.js
+++ b/packages/shex-validator/test/ValidatorEdges-test.js
@@ -249,4 +249,36 @@ describe("validator edges", function () {
     expect(JSON.stringify(res), "and nothing tells the reader how to break it")
       .to.not.include('"repairs"');
   });
+
+  /* The recursion loophole (#14).  <A> genuinely fails -- <a> has no :preda --
+   * and <C> requires @<A>, so <D>'s `:test2 @<C>` must fail.  But <C> is first
+   * reached through `:test @<A>*` while <A> is still on the stack: there <C>'s
+   * `:subject @<A>` is *assumed* to hold (a Recursion), so <C> passed.  That
+   * contingent pass used to be memoized and reused for `:test2 @<C>` after <A>
+   * had failed, and <d> wrongly conformed on the fast engine.  A contingent
+   * result must not outlive its assumption; both engines must fail <d>. */
+  [["eval-simple-1err", require("@shexjs/eval-simple-1err").RegexpModule],
+   ["eval-threaded-nerr", require("@shexjs/eval-threaded-nerr").RegexpModule],
+  ].forEach(([engine, regexModule]) => {
+    it(`does not reuse a recursion-contingent result (#14, ${engine})`, function () {
+      const schema = [
+        `PREFIX : <${BASE}>`,
+        `PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>`,
+        `:D { :predd xsd:string ; ( :test @:A* | :test @:E* ) ; :test2 @:C }`,
+        `:E { :prede xsd:string }`,
+        `:A { :subject @:C ; :preda xsd:string }`,
+        `:C { :subject @:A ; :predc xsd:string }`,
+      ].join("\n");
+      const data = [
+        `PREFIX : <${BASE}>`,
+        `:d :predd "final" ; :test :a ; :test2 :c .`,
+        `:a :subject :c ; :prede "final" .`,
+        `:c :subject :a ; :predc "final" .`,
+      ].join("\n");
+      const result = validatorFor(schema, data, {regexModule})
+        .validateShapeMap([{node: BASE + "d", shape: BASE + "D"}])[0];
+      expect(result.status, JSON.stringify(result.appinfo || result))
+        .to.equal("nonconformant");
+    });
+  });
 });


### PR DESCRIPTION
Fixes #14.

The recursion loophole: a schema like
```
<D> { :predd xsd:string ; ( :test @<A>* | :test @<E>* ) ; :test2 @<C> }
<A> { :subject @<C> ; :preda xsd:string }
<C> { :subject @<A> ; :predc xsd:string }
```
over data where `<a>` is missing `:preda` used to **wrongly conform** on the opt-in fast engine (`eval-simple-1err`).

## Root cause (shared, not engine-specific)
Tracing the validation showed both engines take the same misstep:
```
ENTER a@A
  ENTER c@C
    >> RECURSE a@A (ASSUME PASS)   c@C's :subject @<A> — a@A on the stack → assumed
  EXIT c@C => ShapeTest            c@C passes *contingently*, and is memoized in `known`
EXIT a@A => Failure                a@A actually fails (missing :preda)
...
>> KNOWN-HIT c@C => ShapeTest      :test2 @<C> reuses the stale contingent pass
```
`c@C` passed only because `a@A` was **assumed** on the recursion stack (a `Recursion` node — the greatest-fixed-point step). That contingent result was memoized in the validator's `known` cache and reused for `:test2 @<C>` after `a@A` had failed. (The default engine reused the same stale cache; it only returned the correct `Failure` for an unrelated reason — a spurious excess — so it was right by accident.)

## Fix — evict on falsification
In the shared validator (`shex-validator.ts`): keep memoizing normally, but **when a node/shape pair fails, evict any cached result that passed only by assuming it** — i.e. any `known` entry whose proof carries a `Recursion` on the now-failed pair (walked over the whole proof, so transitive assumptions through nested sub-proofs count). The evicted result is recomputed when next needed, and by then the assumed pair's genuine `Failure` is itself memoized, so the recomputation is cheap and correct.

This is deliberately narrow: eviction only fires on a failure, and only for results that assumed *that* pair. A genuinely-recursive result whose assumption **holds** is never evicted, so valid co-recursion still memoizes exactly as before — the canonical `recursion_example` proof (a 3-node cycle that conforms) is unchanged.

After the fix both engines fail `<d>` for the **right** reason — `:test2 @<C>` → `c@C` recomputed → `a@A` genuinely fails:
```
ENTER c@C                          :test2 @<C> — recomputed, not cache-reused
  >> KNOWN-HIT a@A => Failure       uses a@A's genuine failure
EXIT c@C => Failure
EXIT d@D => Failure                nonconformant ✓
```

## Verification
- Fast engine: `<d>@<D>` now **nonconformant** (was the bug); default engine: still nonconformant, now for the right reason.
- New regression test (`ValidatorEdges-test.js`) asserts nonconformance on **both** engines.
- shexTest validation manifest (both engines): 2424 passing / 0 failing — including `recursion_example`, whose proof is byte-identical to before.
- Base suite (`npm run test`, what the pre-commit hook runs): validator package tests 2561 passing / 0 failing (full base suite deferred to PR CI to avoid holding local server ports)
- `npm run compile` clean.

Note on semantics (see the discussion on #14): this keeps ShEx's greatest-fixed-point evaluation. The bug was never GFP itself — GFP gives the correct answer here — but an unsound *memoization* of a GFP assumption that survived the assumption's refutation. No move to least-fixed-point or stratified semantics is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBCrywES6wuj3RHqExHA7S
